### PR TITLE
production 環境の root 設定を追加

### DIFF
--- a/backend/app/controllers/home_controller.rb
+++ b/backend/app/controllers/home_controller.rb
@@ -1,0 +1,5 @@
+class HomeController < ApplicationController
+  def index
+    render json: { message: "API Root" }
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root 'home#index'
+
   resources :categories
   resources :makers
   resources :users

--- a/backend/spec/requests/home_spec.rb
+++ b/backend/spec/requests/home_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Home", type: :request do
+  describe "#index" do
+    it "レスポンスのステータスがsuccessであること" do
+      get "/"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Render.com へのデプロイは成功したが、ルートが設定されてなく 404 エラーとなる。
Home コントローラを追加して json 形式の簡単なメッセージを出力することで、エラーを解消する。