### PR TITLE
新規ユーザーの登録機能

### DIFF
--- a/frontend/src/components/UsersIndexView.vue
+++ b/frontend/src/components/UsersIndexView.vue
@@ -68,7 +68,7 @@ watch(() => route.query.page, () => {
       </ul>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink to="#">ユーザー情報の登録</RouterLink>
+      <RouterLink to="/users/new">ユーザー情報の登録</RouterLink>
       <RouterLink to="/home">メインメニューへ</RouterLink>
     </div>
   </div>

--- a/frontend/src/components/UsersNewView.vue
+++ b/frontend/src/components/UsersNewView.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { ref } from 'vue'
+
+const name = ref('')
+const department = ref('')
+const password = ref('')
+const password_confirmation = ref('')
+const errorMessage = ref('')
+
+const options = ref([
+  { text: '品質管理部', value: '品質管理部' },
+  { text: '製造部', value: '製造部' },
+  { text: '開発部', value: '開発部' },
+  { text: '営業部', value: '営業部' },
+])
+</script>
+
+<template>
+  <div class="container w-25">
+    <h3 class="text-center mt-5 mb-5">ユーザー情報の登録</h3>
+
+    <form>
+      <label class="form-label" for="user_name">ユーザー名</label>
+      <input v-model="name" class="form-control mb-3" type="text" id="user_name" required>
+
+      <label class="form-label" for="user_department">部署名</label>
+      <select v-model="department" class="form-select mb-3" id="user_department" required>
+        <option value="" label=" "></option>
+        <option v-for="option in options" v-bind:value="option.value">
+          {{ option.text }}
+        </option>
+      </select>
+
+      <label class="form-label" for="user_password">パスワード</label>
+      <input v-model="password" class="form-control mb-3" type="password" id="user_password" required>
+
+      <label class="form-label" for="user_password_confirmation">パスワードの確認</label>
+      <input v-model="password_confirmation" class="form-control mb-4" type="password" id="user_password_confirmation" required>
+
+      <button type="submit" class="form-control btn btn-primary mb-5">登録</button>
+    </form>
+    <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
+    
+    <div class="text-center"><a href="/users">ユーザーリスト</a></div>
+  </div>
+</template>

--- a/frontend/src/components/UsersNewView.vue
+++ b/frontend/src/components/UsersNewView.vue
@@ -22,12 +22,15 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 const userRegistration = async () => {
   try {
     const response = await axios.post(`${API_BASE_URL}/users`, {
-      name: name.value,
-      department: department.value,
-      password: password.value,
-      password_confirmation: password_confirmation.value
+      user: {
+        name: name.value,
+        department: department.value,
+        password: password.value,
+        password_confirmation: password_confirmation.value
+      }
     })
     user.value = response.data
+    console.log(user.value)
     router.push(`/users/${user.value.id}`)
   } catch (error) {
     errorMessage.value = '入力に不備があります。'

--- a/frontend/src/components/UsersNewView.vue
+++ b/frontend/src/components/UsersNewView.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { ref } from 'vue'
+import axios from 'axios'
+import router from '@/router'
 
 const name = ref('')
 const department = ref('')
@@ -13,13 +15,31 @@ const options = ref([
   { text: '開発部', value: '開発部' },
   { text: '営業部', value: '営業部' },
 ])
+
+const user = ref('')
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+const userRegistration = async () => {
+  try {
+    const response = await axios.post(`${API_BASE_URL}/users`, {
+      name: name.value,
+      department: department.value,
+      password: password.value,
+      password_confirmation: password_confirmation.value
+    })
+    user.value = response.data
+    router.push(`/users/${user.value.id}`)
+  } catch (error) {
+    errorMessage.value = '入力に不備があります。'
+  }
+}
 </script>
 
 <template>
   <div class="container w-25">
     <h3 class="text-center mt-5 mb-5">ユーザー情報の登録</h3>
 
-    <form>
+    <form v-on:submit.prevent="userRegistration">
       <label class="form-label" for="user_name">ユーザー名</label>
       <input v-model="name" class="form-control mb-3" type="text" id="user_name" required>
 

--- a/frontend/src/components/UsersNewView.vue
+++ b/frontend/src/components/UsersNewView.vue
@@ -41,6 +41,6 @@ const options = ref([
     </form>
     <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
     
-    <div class="text-center"><a href="/users">ユーザーリスト</a></div>
+    <RouterLink to="/users" class="d-flex justify-content-evenly">ユーザーリスト</RouterLink>
   </div>
 </template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -5,6 +5,7 @@ import HomeView from '@/components/HomeView.vue'
 import SettingsView from '@/components/SettingsView.vue'
 import UsersIndexView from '@/components/UsersIndexView.vue'
 import UsersShowView from '@/components/UsersShowView.vue'
+import UsersNewView from './components/UsersNewView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -14,6 +15,7 @@ const routes = [
   { path: '/settings', component: SettingsView },
   { path: '/users', component: UsersIndexView },
   { path: '/users/:id', component: UsersShowView },
+  { path: '/users/new', component: UsersNewView },
 ]
 
 const router = createRouter({

--- a/frontend/test/component/UsersNewView.test.js
+++ b/frontend/test/component/UsersNewView.test.js
@@ -1,6 +1,17 @@
 import { mount } from '@vue/test-utils'
 import UsersNewView from '@/components/UsersNewView.vue'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import router from '@/router'
+
+const context = describe
+
+vi.mock('axios')
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn()
+  },
+}))
 
 describe('UsersNewView', () => {
   let wrapper
@@ -32,6 +43,46 @@ describe('UsersNewView', () => {
 
     it('RouterLinkのto属性が/usersであること', () => {
       expect(wrapper.find('a').attributes('href')).toBe('/users')
+    })
+  })
+
+  describe('APIデータ取得後のレンダリング', () => {
+    context('正しいユーザー情報を入力した場合', () => {
+      it('ユーザー情報の登録に成功すること', async () => {
+        const mockUser = {
+          data: {
+            name: 'sample user',
+            department: '開発部',
+            password: 'password',
+            password_confirmation: 'password'
+          }
+        }
+        axios.post.mockResolvedValue({ data: { user: mockUser } })
+
+        const nameInput = wrapper.find('input[type="text"]')
+        const departmentSelect = wrapper.find('select')
+        const passwordInput = wrapper.find('input[type="password"][id="user_password"]')
+        const passwordConfirmationInput = wrapper.find('input[type="password"][id="user_password_confirmation"]')
+
+        await nameInput.setValue('sample user')
+        await departmentSelect.setValue('開発部')
+        await passwordInput.setValue('password')
+        await passwordConfirmationInput.setValue('password')
+
+        await wrapper.find('form').trigger('submit.prevent')
+
+        expect(router.push).toHaveBeenCalledWith(`/users/${mockUser.id}`)
+      })
+    })
+
+    context('誤ったユーザー情報を入力した場合', () => {
+      it('ユーザー情報の登録に失敗すること', async () => {
+        axios.post.mockRejectedValue(new Error('Invalid credentials'))
+
+        await wrapper.find('form').trigger('submit.prevent')
+
+        expect(wrapper.text()).toContain('入力に不備があります。')
+      })
     })
   })
 })

--- a/frontend/test/component/UsersNewView.test.js
+++ b/frontend/test/component/UsersNewView.test.js
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils'
+import UsersNewView from '@/components/UsersNewView.vue'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+describe('UsersNewView', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(UsersNewView, {
+      global: {
+        stubs: {
+          RouterLink: {
+            props: ['to'],
+            template: '<a :href="to"><slot /></a>'
+          }
+        }
+      }
+    })
+  })
+
+  describe('コンポーネントのレンダリング', () => {
+    it('見出し「ユーザー情報の登録」が表示されること', () => {
+      expect(wrapper.find('h3').text()).toBe('ユーザー情報の登録')
+    })
+
+    it('入力フォームが表示されること', () => {
+      expect(wrapper.find('form').exists()).toBe(true)
+      expect(wrapper.find('input[type="text"]').exists()).toBe(true)
+      expect(wrapper.find('select').exists()).toBe(true)
+      expect(wrapper.findAll('input[type="password"]').length).toBe(2)
+    })
+
+    it('RouterLinkのto属性が/usersであること', () => {
+      expect(wrapper.find('a').attributes('href')).toBe('/users')
+    })
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -16,5 +16,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    silent: true
   },
 })


### PR DESCRIPTION
## 概要
既存の users/new ビューを Vue.js + Bootstrap でリファインする。

## 実装の流れ
- [x] 新規登録ページ
- [x] 新規登録ページのテスト
- [x] 登録機能
- [x] 登録機能のテスト

## テスト内容
- コンポーネントのレンダリング
  - 見出し「ユーザー情報の登録」が表示されること
  - 入力フォームがあること
  - RouterLink の to 属性が /users であること
- APIデータ取得後のレンダリング
  - 正しいユーザー情報を入力した場合
    - ユーザー情報の登録に成功すること
  - 誤ったユーザー情報を入力した場合
    - ユーザー情報の登録に失敗すること
#### 追加タスク
- [x] データベースにパスワードが登録されない件の解消