### PR TITLE
カテゴリー一覧の表示機能

### DIFF
--- a/frontend/src/components/HomeView.vue
+++ b/frontend/src/components/HomeView.vue
@@ -74,7 +74,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">カテゴリーの管理</h5>
             <p class="card-text">カテゴリーに関する情報を一括管理します。</p>
-            <RouterLink to="#" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/categories" class="card-link">管理ページへ</RouterLink>
           </div>
         </div>
       </div>

--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -1,5 +1,22 @@
 <script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const categories = ref([])
+
+const fetchCategoryList = async () => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/categories`)
+    categories.value = response.data
+  } catch (error) {
+    console.error('Get category list failed')
+  }
+}
+
+onMounted(() => {
+  fetchCategoryList()
+})
 </script>
 
 <template>
@@ -14,39 +31,11 @@
         </div>
       </div>
 
-      <RouterLink to="#" class="list-group-item list-group-item-action">
+      <RouterLink v-for="category in categories" v-bind:key="category.id" class="list-group-item list-group-item-action" to="#">
         <div class="d-flex w-100 justify-content-between">
-          <h6>めっき</h6>
-          <h6>金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。</h6>
+          <h6>{{ category.item }}</h6>
+          <h6>{{ category.summary }}</h6>
         </div>        
-      </RouterLink>
-
-      <RouterLink to="#" class="list-group-item list-group-item-action">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>陽極酸化</h6>
-          <h6>人工的にアルミニウム表面に分厚い酸化アルミニウム被膜を作る処理のこと。</h6>
-        </div>
-      </RouterLink>
-
-      <RouterLink to="#" class="list-group-item list-group-item-action">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>化成</h6>
-          <h6>金属の表面に処理剤を作用させて化学反応を起こさせる処理のこと。</h6>
-        </div>
-      </RouterLink>
-
-      <RouterLink to="#" class="list-group-item list-group-item-action">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>コーティング</h6>
-          <h6>溶射金属やセラミックスの粉末を、溶解状態にして製品表面に吹き付ける処理のこと。</h6>
-        </div>
-      </RouterLink>
-
-      <RouterLink to="#" class="list-group-item list-group-item-action">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>表面硬化</h6>
-          <h6>主に金属材料に対して行われる、加熱・冷却・雰囲気により材料の性質を変化させる処理のこと。</h6>
-        </div>
       </RouterLink>
     </div>
 

--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -5,10 +5,19 @@ import axios from 'axios'
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 const categories = ref([])
 
+function replaceStringWithEllipsis() {
+  for (let i = 0; i < categories.value.length; i++) {
+    if (categories.value[i].summary.length > 10) {
+      categories.value[i].summary = categories.value[i].summary.slice(0, 10) + '...'  
+    }
+  }
+}
+
 const fetchCategoryList = async () => {
   try {
     const response = await axios.get(`${API_BASE_URL}/categories`)
     categories.value = response.data
+    replaceStringWithEllipsis()
   } catch (error) {
     console.error('Get category list failed')
   }
@@ -20,7 +29,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="container w-50">
+  <div class="container w-25">
     <h3 class="text-center mt-5 mb-5">カテゴリーリスト</h3>
 
     <div class="list-group list-group-flush mb-5">

--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -1,3 +1,7 @@
+<script setup>
+
+</script>
+
 <template>
   <div class="container w-50">
     <h3 class="text-center mt-5 mb-5">カテゴリーリスト</h3>
@@ -10,41 +14,45 @@
         </div>
       </div>
 
-      <a class="list-group-item list-group-item-action" href="/categories/1">
+      <RouterLink to="#" class="list-group-item list-group-item-action">
         <div class="d-flex w-100 justify-content-between">
           <h6>めっき</h6>
           <h6>金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。</h6>
-        </div>
-      </a>
-      <a class="list-group-item list-group-item-action" href="/categories/2">
+        </div>        
+      </RouterLink>
+
+      <RouterLink to="#" class="list-group-item list-group-item-action">
         <div class="d-flex w-100 justify-content-between">
           <h6>陽極酸化</h6>
           <h6>人工的にアルミニウム表面に分厚い酸化アルミニウム被膜を作る処理のこと。</h6>
         </div>
-      </a>
-      <a class="list-group-item list-group-item-action" href="/categories/3">
+      </RouterLink>
+
+      <RouterLink to="#" class="list-group-item list-group-item-action">
         <div class="d-flex w-100 justify-content-between">
           <h6>化成</h6>
           <h6>金属の表面に処理剤を作用させて化学反応を起こさせる処理のこと。</h6>
         </div>
-      </a>
-      <a class="list-group-item list-group-item-action" href="/categories/4">
+      </RouterLink>
+
+      <RouterLink to="#" class="list-group-item list-group-item-action">
         <div class="d-flex w-100 justify-content-between">
           <h6>コーティング</h6>
           <h6>溶射金属やセラミックスの粉末を、溶解状態にして製品表面に吹き付ける処理のこと。</h6>
         </div>
-      </a>
-      <a class="list-group-item list-group-item-action" href="/categories/5">
+      </RouterLink>
+
+      <RouterLink to="#" class="list-group-item list-group-item-action">
         <div class="d-flex w-100 justify-content-between">
           <h6>表面硬化</h6>
           <h6>主に金属材料に対して行われる、加熱・冷却・雰囲気により材料の性質を変化させる処理のこと。</h6>
         </div>
-      </a>
+      </RouterLink>
     </div>
 
     <div class="d-flex justify-content-evenly">
-      <a href="/categories/new">カテゴリー情報の登録</a>
-      <a href="/home">メインメニューへ</a>
+      <RouterLink to="#">カテゴリー情報の登録</RouterLink>
+      <RouterLink to="/home">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="container w-50">
+    <h3 class="text-center mt-5 mb-5">カテゴリーリスト</h3>
+
+    <div class="list-group list-group-flush mb-5">
+      <div class="list-group-item list-group-item-action">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>カテゴリー名</h6>
+          <h6>概要</h6>
+        </div>
+      </div>
+
+      <a class="list-group-item list-group-item-action" href="/categories/1">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>めっき</h6>
+          <h6>金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。</h6>
+        </div>
+      </a>
+      <a class="list-group-item list-group-item-action" href="/categories/2">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>陽極酸化</h6>
+          <h6>人工的にアルミニウム表面に分厚い酸化アルミニウム被膜を作る処理のこと。</h6>
+        </div>
+      </a>
+      <a class="list-group-item list-group-item-action" href="/categories/3">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>化成</h6>
+          <h6>金属の表面に処理剤を作用させて化学反応を起こさせる処理のこと。</h6>
+        </div>
+      </a>
+      <a class="list-group-item list-group-item-action" href="/categories/4">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>コーティング</h6>
+          <h6>溶射金属やセラミックスの粉末を、溶解状態にして製品表面に吹き付ける処理のこと。</h6>
+        </div>
+      </a>
+      <a class="list-group-item list-group-item-action" href="/categories/5">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>表面硬化</h6>
+          <h6>主に金属材料に対して行われる、加熱・冷却・雰囲気により材料の性質を変化させる処理のこと。</h6>
+        </div>
+      </a>
+    </div>
+
+    <div class="d-flex justify-content-evenly">
+      <a href="/categories/new">カテゴリー情報の登録</a>
+      <a href="/home">メインメニューへ</a>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -7,6 +7,7 @@ import UsersIndexView from '@/components/UsersIndexView.vue'
 import UsersShowView from '@/components/UsersShowView.vue'
 import UsersNewView from '@/components/UsersNewView.vue'
 import UsersEditView from '@/components/UsersEditView.vue'
+import CategoriesIndexView from '@/components/categories/CategoriesIndexView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -18,6 +19,7 @@ const routes = [
   { path: '/users/:id', component: UsersShowView },
   { path: '/users/new', component: UsersNewView },
   { path: '/users/:id/edit', component: UsersEditView },
+  { path: '/categories', component: CategoriesIndexView },
 ]
 
 const router = createRouter({

--- a/frontend/test/component/HomeView.test.js
+++ b/frontend/test/component/HomeView.test.js
@@ -67,7 +67,7 @@ describe('HomeView', () => {
       expect(links[2].attributes('href')).toBe('#')
       expect(links[3].attributes('href')).toBe('#')
       expect(links[4].attributes('href')).toBe('#')
-      expect(links[5].attributes('href')).toBe('#')
+      expect(links[5].attributes('href')).toBe('/categories')
       expect(links[6].attributes('href')).toBe('#')
       expect(links[7].attributes('href')).toBe('/users')
       expect(links[8].attributes('href')).toBe('/settings')

--- a/frontend/test/component/categories/CategoriesIndexView.test.js
+++ b/frontend/test/component/categories/CategoriesIndexView.test.js
@@ -22,7 +22,7 @@ describe('CategoriesIndexView', () => {
       const wrapper = mount(CategoriesIndexView)
       const links = wrapper.findAll('routerlink[to="#"]')
 
-      expect(links[5].text()).toBe('カテゴリー情報の登録')
+      expect(links[0].text()).toBe('カテゴリー情報の登録')
       expect(wrapper.find('routerlink[to="/home"]').text()).toBe('メインメニューへ')
     })
   })

--- a/frontend/test/component/categories/CategoriesIndexView.test.js
+++ b/frontend/test/component/categories/CategoriesIndexView.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CategoriesIndexView from '@/components/categories/CategoriesIndexView.vue'
+
+describe('CategoriesIndexView', () => {
+  describe('コンポーネントのレンダリング', () => {
+    it('「カテゴリーリスト」の見出しが表示されること', () => {
+      const wrapper = mount(CategoriesIndexView)
+
+      expect(wrapper.find('h3').text()).toBe('カテゴリーリスト')
+    })
+
+    it('「カテゴリー名」と「概要」のラベルが表示されること', () => {
+      const wrapper = mount(CategoriesIndexView)
+      const links = wrapper.findAll('h6')
+
+      expect(links[0].text()).toBe('カテゴリー名')
+      expect(links[1].text()).toBe('概要')
+    })
+
+    it('「カテゴリー情報の登録」と「メインメニューへ」のリンクが表示されること', () => {
+      const wrapper = mount(CategoriesIndexView)
+      const links = wrapper.findAll('routerlink[to="#"]')
+
+      expect(links[5].text()).toBe('カテゴリー情報の登録')
+      expect(wrapper.find('routerlink[to="/home"]').text()).toBe('メインメニューへ')
+    })
+  })
+})


### PR DESCRIPTION
## 概要
Rails ビューの categories/index の復元。

## 実装
- [x] ルーティング定義
- [x] index ページ作成
- [x] リンク設定
- [x] テスト作成
- [x] API通信
- [x] UI/UXの調整

#### UI/UXの調整について
概要のテキストが長すぎるので、Bootstrap の .text-truncate を使って省略する。

## 参考情報
- [Bootstrap5 - テキスト省略](https://getbootstrap.jp/docs/5.3/helpers/text-truncation/)