### PR TITLE
カテゴリーの新規登録機能

### DIFF
--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -49,7 +49,7 @@ onMounted(() => {
     </div>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink to="#">カテゴリー情報の登録</RouterLink>
+      <RouterLink to="/categories/new">カテゴリー情報の登録</RouterLink>
       <RouterLink to="/home">メインメニューへ</RouterLink>
     </div>
   </div>

--- a/frontend/src/components/categories/CategoriesNewView.vue
+++ b/frontend/src/components/categories/CategoriesNewView.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="container w-25">
+    <h3 class="text-center mt-5 mb-5">カテゴリー情報の登録</h3>
+
+    <form>
+      <label class="form-label" for="category_item">カテゴリー名</label>
+      <input class="form-control mb-4" type="text" name="category[item]" id="category_item" />
+
+      <label class="form-label" for="category_summary">概要</label>
+      <input class="form-control mb-4" type="text" name="category[summary]" id="category_summary" />
+
+      <input type="submit" name="commit" value="登録" class="form-control btn btn-primary mb-5" data-disable-with="登録" />
+    </form>
+
+    <div class="text-center">
+      <a href="/categories">カテゴリーリストへ</a>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/categories/CategoriesNewView.vue
+++ b/frontend/src/components/categories/CategoriesNewView.vue
@@ -12,8 +12,8 @@
       <input type="submit" name="commit" value="登録" class="form-control btn btn-primary mb-5" data-disable-with="登録" />
     </form>
 
-    <div class="text-center">
-      <a href="/categories">カテゴリーリストへ</a>
+    <div class="d-flex justify-content-evenly">
+      <RouterLink to="/categories">カテゴリーリストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/categories/CategoriesNewView.vue
+++ b/frontend/src/components/categories/CategoriesNewView.vue
@@ -18,13 +18,11 @@
         }
       })
       category.value = response.data
-      console.log(category.value)
       router.push(`/categories/${category.value.id}`)
     } catch (error) {
       errorMessage.value = '入力に不備があります。'
     }
   }
-
 </script>
 
 <template>
@@ -36,15 +34,13 @@
       <input v-model="item" class="form-control mb-4" type="text" id="category_item" required/>
 
       <label class="form-label" for="category_summary">概要</label>
-      <input v-model="summary" class="form-control mb-4" type="text" id="category_summary" required/>
-
-      <input type="submit" name="commit" value="登録" class="form-control btn btn-primary mb-5" data-disable-with="登録" />
+      <textarea v-model="summary" class="form-control mb-4" id="category_summary" required></textarea>
+      
+      <button type="submit" class="form-control btn btn-primary mb-5">登録</button>
     </form>
 
     <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
 
-    <div class="d-flex justify-content-evenly">
-      <RouterLink to="/categories">カテゴリーリストへ</RouterLink>
-    </div>
+    <RouterLink to="/categories" class="d-flex justify-content-evenly">カテゴリーリストへ</RouterLink>
   </div>
 </template>

--- a/frontend/src/components/categories/CategoriesNewView.vue
+++ b/frontend/src/components/categories/CategoriesNewView.vue
@@ -6,6 +6,7 @@
   const item = ref('')
   const summary = ref('')
   const category = ref('')
+  const errorMessage = ref('')
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 
   const categoryRegistration = async () => {
@@ -20,7 +21,7 @@
       console.log(category.value)
       router.push(`/categories/${category.value.id}`)
     } catch (error) {
-      console.error('Category registration failed.')
+      errorMessage.value = '入力に不備があります。'
     }
   }
 
@@ -39,6 +40,8 @@
 
       <input type="submit" name="commit" value="登録" class="form-control btn btn-primary mb-5" data-disable-with="登録" />
     </form>
+
+    <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
 
     <div class="d-flex justify-content-evenly">
       <RouterLink to="/categories">カテゴリーリストへ</RouterLink>

--- a/frontend/src/components/categories/CategoriesNewView.vue
+++ b/frontend/src/components/categories/CategoriesNewView.vue
@@ -1,13 +1,41 @@
+<script setup>
+  import { ref } from 'vue'
+  import axios from 'axios'
+  import router from '@/router'
+
+  const item = ref('')
+  const summary = ref('')
+  const category = ref('')
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+  const categoryRegistration = async () => {
+    try {
+      const response = await axios.post(`${API_BASE_URL}/categories`, {
+        category: {
+          item: item.value,
+          summary: summary.value
+        }
+      })
+      category.value = response.data
+      console.log(category.value)
+      router.push(`/categories/${category.value.id}`)
+    } catch (error) {
+      console.error('Category registration failed.')
+    }
+  }
+
+</script>
+
 <template>
   <div class="container w-25">
     <h3 class="text-center mt-5 mb-5">カテゴリー情報の登録</h3>
 
-    <form>
+    <form v-on:submit.prevent="categoryRegistration">
       <label class="form-label" for="category_item">カテゴリー名</label>
-      <input class="form-control mb-4" type="text" name="category[item]" id="category_item" />
+      <input v-model="item" class="form-control mb-4" type="text" id="category_item" required/>
 
       <label class="form-label" for="category_summary">概要</label>
-      <input class="form-control mb-4" type="text" name="category[summary]" id="category_summary" />
+      <input v-model="summary" class="form-control mb-4" type="text" id="category_summary" required/>
 
       <input type="submit" name="commit" value="登録" class="form-control btn btn-primary mb-5" data-disable-with="登録" />
     </form>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -9,6 +9,7 @@ import UsersNewView from '@/components/UsersNewView.vue'
 import UsersEditView from '@/components/UsersEditView.vue'
 import CategoriesIndexView from '@/components/categories/CategoriesIndexView.vue'
 import CategoriesShowView from './components/categories/CategoriesShowView.vue'
+import CategoriesNewView from './components/categories/CategoriesNewView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -22,6 +23,7 @@ const routes = [
   { path: '/users/:id/edit', component: UsersEditView },
   { path: '/categories', component: CategoriesIndexView },
   { path: '/categories/:id', component: CategoriesShowView },
+  { path: '/categories/new', component: CategoriesNewView },
 ]
 
 const router = createRouter({

--- a/frontend/test/component/categories/CategoriesIndexView.test.js
+++ b/frontend/test/component/categories/CategoriesIndexView.test.js
@@ -19,11 +19,17 @@ describe('CategoriesIndexView', () => {
     })
 
     it('「カテゴリー情報の登録」と「メインメニューへ」のリンクが表示されること', () => {
-      const wrapper = mount(CategoriesIndexView)
-      const links = wrapper.findAll('routerlink[to="#"]')
+      const wrapper = mount(CategoriesIndexView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+      const links = wrapper.findAll('a')
 
       expect(links[0].text()).toBe('カテゴリー情報の登録')
-      expect(wrapper.find('routerlink[to="/home"]').text()).toBe('メインメニューへ')
+      expect(links[1].text()).toBe('メインメニューへ')
     })
   })
 

--- a/frontend/test/component/categories/CategoriesNewView.test.js
+++ b/frontend/test/component/categories/CategoriesNewView.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 import CategoriesNewView from '@/components/categories/CategoriesNewView.vue'
 import axios from 'axios'
@@ -14,59 +14,44 @@ vi.mock('@/router', () => {
   }
 })
 
-describe('CategoriesNewView コンポーネントをレンダリングした時に、', () => {
-  it('見出し「カテゴリー情報の登録」が表示されること。', () => {
-    const wrapper = mount(CategoriesNewView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
-        }
-      }
-    })
+let wrapper
 
+beforeEach(() => {
+  wrapper = mount(CategoriesNewView, {
+    global: {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    }
+  })
+})
+
+describe('コンポーネントをレンダリングした時に、', () => {  
+  it('見出し「カテゴリー情報の登録」が表示されること。', () => {
     expect(wrapper.find('h3').text()).toBe('カテゴリー情報の登録')
   })
 
   it('入力フォームが表示されること。', () => {
-    const wrapper = mount(CategoriesNewView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
-        }
-      }
-    })
-
     expect(wrapper.find('form').exists()).toBe(true)
-    expect(wrapper.findAll('label')[0].text()).toBe('カテゴリー名')
-    expect(wrapper.findAll('label')[1].text()).toBe('概要')
-    expect(wrapper.findAll('input[type="text"]').length).toBe(2)
-    expect(wrapper.find('input[type="submit"][value="登録"]').exists()).toBe(true)
+    expect(wrapper.find('label[for="category_item"]').text()).toBe('カテゴリー名')
+    expect(wrapper.find('label[for="category_summary"]').text()).toBe('概要')
+    expect(wrapper.find('input[id="category_item"]').exists()).toBe(true)
+    expect(wrapper.find('textarea').exists()).toBe(true)
+    expect(wrapper.find('button').exists()).toBe(true)
   })
 
   it('外部リンク「カテゴリーリストへ」が表示されること', () => {
-    const wrapper = mount(CategoriesNewView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
-        }
-      }
-    })
+    expect(wrapper.findComponent(RouterLinkStub).text()).toBe('カテゴリーリストへ')
+  })
 
-    expect(wrapper.find('a').text()).toBe('カテゴリーリストへ')
+  it('外部リンク「カテゴリーリストへ」のto属性は/categoriesであること', () => {
+    expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/categories')
   })
 })
 
 describe('カテゴリー登録で', () => {
   describe('有効な情報を入力した場合、', () => {
     it('登録が成功すること', async () => {
-      const wrapper = mount(CategoriesNewView, {
-        global: {
-          stubs: {
-            RouterLink: RouterLinkStub
-          }
-        }
-      })
-
       const mockCategory = {
         data: {
           item: 'test item',
@@ -77,10 +62,10 @@ describe('カテゴリー登録で', () => {
       axios.post.mockResolvedValue({ data: { category: mockCategory} })
 
       const itemInput = wrapper.find('input[id="category_item"]')
-      const summaryInput = wrapper.find('input[id="category_summary"]')
+      const summaryTextArea = wrapper.find('textarea')
 
       await itemInput.setValue('test item')
-      await summaryInput.setValue('test summary')
+      await summaryTextArea.setValue('test summary')
       await wrapper.find('form').trigger('submit.prevent')
 
       expect(router.push).toHaveBeenCalledWith(`/categories/${mockCategory.id}`)
@@ -89,14 +74,6 @@ describe('カテゴリー登録で', () => {
 
   describe('無効な情報を入力した場合、', () => {
     it('登録が失敗すること', async () => {
-      const wrapper = mount(CategoriesNewView, {
-        global: {
-          stubs: {
-            RouterLink: RouterLinkStub
-          }
-        }
-      })
-
       axios.post.mockRejectedValue(new Error('Invalid credentials'))
 
       await wrapper.find('form').trigger('submit.prevent')

--- a/frontend/test/component/categories/CategoriesNewView.test.js
+++ b/frontend/test/component/categories/CategoriesNewView.test.js
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 import CategoriesNewView from '@/components/categories/CategoriesNewView.vue'
+import axios from 'axios'
+import router from '@/router'
+
+vi.mock('axios')
+
+vi.mock('@/router', () => {
+  return {
+    default: {
+      push: vi.fn()
+    }
+  }
+})
 
 describe('CategoriesNewView コンポーネントをレンダリングした時に、', () => {
   it('見出し「カテゴリー情報の登録」が表示されること。', () => {
@@ -41,5 +53,55 @@ describe('CategoriesNewView コンポーネントをレンダリングした時�
     })
 
     expect(wrapper.find('a').text()).toBe('カテゴリーリストへ')
+  })
+})
+
+describe('カテゴリー登録で', () => {
+  describe('有効な情報を入力した場合、', () => {
+    it('登録が成功すること', async () => {
+      const wrapper = mount(CategoriesNewView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      const mockCategory = {
+        data: {
+          item: 'test item',
+          summary: 'test summary'
+        }
+      }
+
+      axios.post.mockResolvedValue({ data: { category: mockCategory} })
+
+      const itemInput = wrapper.find('input[id="category_item"]')
+      const summaryInput = wrapper.find('input[id="category_summary"]')
+
+      await itemInput.setValue('test item')
+      await summaryInput.setValue('test summary')
+      await wrapper.find('form').trigger('submit.prevent')
+
+      expect(router.push).toHaveBeenCalledWith(`/categories/${mockCategory.id}`)
+    })
+  })
+
+  describe('無効な情報を入力した場合、', () => {
+    it('登録が失敗すること', async () => {
+      const wrapper = mount(CategoriesNewView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      axios.post.mockRejectedValue(new Error('Invalid credentials'))
+
+      await wrapper.find('form').trigger('submit.prevent')
+
+      expect(wrapper.text()).toContain('入力に不備があります。')
+    })
   })
 })

--- a/frontend/test/component/categories/CategoriesNewView.test.js
+++ b/frontend/test/component/categories/CategoriesNewView.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CategoriesNewView from '@/components/categories/CategoriesNewView.vue'
+
+describe('CategoriesNewView コンポーネントをレンダリングした時に、', () => {
+  it('見出し「カテゴリー情報の登録」が表示されること。', () => {
+    const wrapper = mount(CategoriesNewView)
+
+    expect(wrapper.find('h3').text()).toBe('カテゴリー情報の登録')
+  })
+
+  it('入力フォームが表示されること。', () => {
+    const wrapper = mount(CategoriesNewView)
+
+    expect(wrapper.find('form').exists()).toBe(true)
+    expect(wrapper.findAll('label')[0].text()).toBe('カテゴリー名')
+    expect(wrapper.findAll('label')[1].text()).toBe('概要')
+    expect(wrapper.findAll('input[type="text"]').length).toBe(2)
+    expect(wrapper.find('input[type="submit"][value="登録"]').exists()).toBe(true)
+  })
+
+  it('外部リンク「カテゴリーリストへ」が表示されること', () => {
+    const wrapper = mount(CategoriesNewView)
+
+    expect(wrapper.find('a').text()).toBe('カテゴリーリストへ')
+  })
+})

--- a/frontend/test/component/categories/CategoriesNewView.test.js
+++ b/frontend/test/component/categories/CategoriesNewView.test.js
@@ -1,16 +1,28 @@
 import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import CategoriesNewView from '@/components/categories/CategoriesNewView.vue'
 
 describe('CategoriesNewView コンポーネントをレンダリングした時に、', () => {
   it('見出し「カテゴリー情報の登録」が表示されること。', () => {
-    const wrapper = mount(CategoriesNewView)
+    const wrapper = mount(CategoriesNewView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
 
     expect(wrapper.find('h3').text()).toBe('カテゴリー情報の登録')
   })
 
   it('入力フォームが表示されること。', () => {
-    const wrapper = mount(CategoriesNewView)
+    const wrapper = mount(CategoriesNewView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
 
     expect(wrapper.find('form').exists()).toBe(true)
     expect(wrapper.findAll('label')[0].text()).toBe('カテゴリー名')
@@ -20,7 +32,13 @@ describe('CategoriesNewView コンポーネントをレンダリングした時�
   })
 
   it('外部リンク「カテゴリーリストへ」が表示されること', () => {
-    const wrapper = mount(CategoriesNewView)
+    const wrapper = mount(CategoriesNewView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
 
     expect(wrapper.find('a').text()).toBe('カテゴリーリストへ')
   })


### PR DESCRIPTION
## 概要
Rails ビューの categories/new を Vue.js でリファインする。
コンポーネント名：CategoriesNewView.vue
テスト名：CategoriesNewView.test.js

## 実装
- [x] コンポーネント
- [x] ルーティング
- [x] レンダリングのテスト
- [x] API 通信
- [x] リクエスト・レスポンスのテスト
- [x] リンク設定
- [x] リンクのテスト
- [x] UI/UX の調整
- [x] リファクタリング

## 改善点
- [x] 概要のテキスト入力を「入力要素」から「テキストエリア要素」に変更。
- [x] 登録ボタンを「入力要素」から「ボタン要素」に変更。
- [x] リンク要素をfindComponent(RouterLinkStub)を使って絞り込む。
- [x] コンポーネントのマウントをbeforeEachを使って重複を解消。
- [x] RouterLink to属性の検証
- [x] RouterLink 内に flexbox を定義するか外で定義するか？
- [x] エラーメッセージの表示