### PR TITLE
メーカー一覧の表示機能

### DIFF
--- a/backend/app/controllers/makers_controller.rb
+++ b/backend/app/controllers/makers_controller.rb
@@ -1,8 +1,10 @@
 class MakersController < ApplicationController
   def index
-    @makers = Maker.all
+    makers = Maker.paginate(page: params[:page], per_page: 9)
 
-    render json: @makers
+    render json: {
+      makers: makers, current_page: makers.current_page, total_pages: makers.total_pages
+    }
   end
 
   def show

--- a/backend/app/controllers/makers_controller.rb
+++ b/backend/app/controllers/makers_controller.rb
@@ -1,6 +1,6 @@
 class MakersController < ApplicationController
   def index
-    makers = Maker.paginate(page: params[:page], per_page: 9)
+    makers = Maker.paginate(page: params[:page], per_page: 7)
 
     render json: {
       makers: makers, current_page: makers.current_page, total_pages: makers.total_pages

--- a/backend/spec/requests/makers_spec.rb
+++ b/backend/spec/requests/makers_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Makers API", type: :request do
   describe '#index' do
     before do
-      FactoryBot.create_list(:maker_list, 9)
+      FactoryBot.create_list(:maker_list, 7)
     end
 
     it 'レスポンスのステータスがsuccessであること' do
@@ -11,10 +11,10 @@ RSpec.describe "Makers API", type: :request do
       expect(response).to have_http_status(:success)
     end
 
-    it 'レスポンスのmakersは9件であること' do
+    it 'レスポンスのmakersは7件であること' do
       get "/makers"
       json = JSON.parse(response.body)
-      expect(json['makers'].length).to eq(9)
+      expect(json['makers'].length).to eq(7)
     end
 
     it 'レスポンスのcurrent_pageは1であること' do

--- a/backend/spec/requests/makers_spec.rb
+++ b/backend/spec/requests/makers_spec.rb
@@ -11,10 +11,22 @@ RSpec.describe "Makers API", type: :request do
       expect(response).to have_http_status(:success)
     end
 
-    it 'メーカーリストが9件返ること' do
+    it 'レスポンスのmakersは9件であること' do
       get "/makers"
       json = JSON.parse(response.body)
-      expect(json.count).to eq(9)
+      expect(json['makers'].length).to eq(9)
+    end
+
+    it 'レスポンスのcurrent_pageは1であること' do
+      get "/makers"
+      json = JSON.parse(response.body)
+      expect(json['current_page']).to eq(1)
+    end
+    
+    it 'レスポンスのtotal_pagesは1であること' do
+      get "/makers"
+      json = JSON.parse(response.body)
+      expect(json['total_pages']).to eq(1)
     end
   end
 

--- a/frontend/src/components/HomeView.vue
+++ b/frontend/src/components/HomeView.vue
@@ -84,7 +84,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">メーカーの管理</h5>
             <p class="card-text">メーカーに関する情報を一括管理します。</p>
-            <RouterLink to="#" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/makers" class="card-link">管理ページへ</RouterLink>
           </div>
         </div>
       </div>

--- a/frontend/src/components/makers/MakersIndexView.vue
+++ b/frontend/src/components/makers/MakersIndexView.vue
@@ -1,3 +1,41 @@
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import axios from 'axios'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const route = useRoute()
+const makers = ref([])
+const currentPage = ref(Number(route.query.page) || 1)
+const totalPages = ref(1)
+
+const fetchMakerList = async () => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/makers?page=${currentPage.value}`)
+    const data = response.data
+    makers.value = data.makers
+    currentPage.value = data.current_page
+    totalPages.value = data.total_pages
+  } catch (error) {
+    console.error('Get maker list failed')
+  }
+}
+
+const getPageLink = (page) => ({
+  path: route.path,
+  query: { page }
+})
+
+watch(() => route.query.page, (newPage) => {
+  currentPage.value = Number(newPage) || 1
+  fetchMakerList()
+}, { immediate: true })
+
+onMounted(() => {
+  fetchMakerList()
+})
+</script>
+
 <template>
   <div class="container w-50">
     <h3 class="text-center mt-5 mb-5">メーカーリスト</h3>
@@ -10,143 +48,31 @@
         </div>
       </div>
 
-      <a class="list-group-item list-group-item-action" href="#">
+      <RouterLink v-for="maker in makers" v-bind:key="maker.id" class="list-group-item list-group-item-action" to="#">
         <div class="d-flex justify-content-between">
-          <h6>長谷川水産合資会社</h6>
-          <small>TEL: 080-5808-0222</small>
+          <h6>{{ maker.name }}</h6>
+          <small>{{ maker.phone_number }}</small>
         </div>
         <div class="d-flex justify-content-between">
-          <small>〒106-6145 東京都渋谷区神南1-2-0</small>
-          <small>FAX: 070-9532-2874</small>
+          <small>{{ maker.address }}</small>
+          <small>{{ maker.fax_number }}</small>
         </div>
-      </a>
-
-      <a class="list-group-item list-group-item-action" href="#">
-        <div class="d-flex justify-content-between">
-          <h6>大野印刷株式会社</h6>
-          <small>TEL: 090-1157-4630</small>
-        </div>
-        <div class="d-flex justify-content-between">
-          <small>〒590-0928 東京都渋谷区神南1-2-1</small>
-          <small>FAX: 070-8662-0619</small>
-        </div>
-      </a>
-
-      <a class="list-group-item list-group-item-action" href="#">
-        <div class="d-flex justify-content-between">
-          <h6>佐々木食品株式会社</h6>
-          <small>TEL: 080-6616-2999</small>
-        </div>
-        <div class="d-flex justify-content-between">
-          <small>〒039-4152 東京都渋谷区神南1-2-2</small>
-          <small>FAX: 070-6702-6634</small>
-        </div>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="#">
-        <div class="d-flex justify-content-between">
-          <h6>合資会社山本印刷</h6>
-          <small>TEL: 090-3466-6784</small>
-        </div>
-        <div class="d-flex justify-content-between">
-          <small>〒479-0045 東京都渋谷区神南1-2-3</small>
-          <small>FAX: 080-6811-0656</small>
-        </div>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="#">
-        <div class="d-flex justify-content-between">
-          <h6>合名会社山田印刷</h6>
-          <small>TEL: 080-9274-1520</small>
-        </div>
-        <div class="d-flex justify-content-between">
-          <small>〒761-4423 東京都渋谷区神南1-2-4</small>
-          <small>FAX: 090-5827-2604</small>
-        </div>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="#">
-        <div class="d-flex justify-content-between">
-          <h6>金子農林合名会社</h6>
-          <small>TEL: 070-6909-6952</small>
-        </div>
-        <div class="d-flex justify-content-between">
-          <small>〒292-0801 東京都渋谷区神南1-2-5</small>
-          <small>FAX: 070-8503-0054</small>
-        </div>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="#">
-        <div class="d-flex justify-content-between">
-          <h6>合資会社杉山ガス</h6>
-          <small>TEL: 080-2228-3988</small>
-        </div>
-        <div class="d-flex justify-content-between">
-          <small>〒612-8484 東京都渋谷区神南1-2-6</small>
-          <small>FAX: 070-1981-8467</small>
-        </div>
-      </a>      
+      </RouterLink>
     </div>
 
-    <ul class="pagination justify-content-center mb-5">
-      <li class="page-item disabled">
-        <a class="page-link">前のページ</a>
+    <ul v-if="totalPages > 0"  class="pagination justify-content-center mb-5">
+      <li class="page-item" :class="{ disabled: currentPage === 1 }">
+        <RouterLink class="page-link" v-if="currentPage > 1" v-bind:to="getPageLink(currentPage - 1)">前ページ</RouterLink>
+        <span v-else class="page-link">前ページ</span>
       </li>
-      
-      <li class="page-item active">
-        <a class="page-link" href="#">1</a>
+
+      <li v-for="page in totalPages" v-bind:key="page" class="page-item" v-bind:class="{ active: page === currentPage }">
+        <RouterLink class="page-link" v-bind:to="getPageLink(page)">{{ page }}</RouterLink>
       </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">2</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">3</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">4</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">5</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">6</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">7</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">8</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">9</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">10</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">11</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">12</a>
-      </li>
-      
-      <li class="page-item ">
-        <a class="page-link" href="#">13</a>
-      </li>
-      
-      <li class="page-item">
-        <a class="page-link" href="#">次のページ</a>
+
+      <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+        <RouterLink class="page-link" v-if="currentPage < totalPages" v-bind:to="getPageLink(currentPage + 1)">次ページ</RouterLink>
+        <span v-else class="page-link">次ページ</span>
       </li>
     </ul>
 

--- a/frontend/src/components/makers/MakersIndexView.vue
+++ b/frontend/src/components/makers/MakersIndexView.vue
@@ -77,8 +77,8 @@ onMounted(() => {
     </ul>
 
     <div class="d-flex justify-content-evenly">
-      <a href="#">メーカー情報の登録</a>
-      <a href="#">メインメニューへ</a>
+      <RouterLink to="#">メーカー情報の登録</RouterLink>
+      <RouterLink to="/home">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/makers/MakersIndexView.vue
+++ b/frontend/src/components/makers/MakersIndexView.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="container w-50">
+    <h3 class="text-center mt-5 mb-5">メーカーリスト</h3>
+
+    <div class="list-group list-group-flush mb-5">
+      <div class="list-group-item list-group-item-action">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>メーカー名 / 住所</h6>
+          <h6>電話番号 / FAX番号</h6>
+        </div>
+      </div>
+
+      <a class="list-group-item list-group-item-action" href="#">
+        <div class="d-flex justify-content-between">
+          <h6>長谷川水産合資会社</h6>
+          <small>TEL: 080-5808-0222</small>
+        </div>
+        <div class="d-flex justify-content-between">
+          <small>〒106-6145 東京都渋谷区神南1-2-0</small>
+          <small>FAX: 070-9532-2874</small>
+        </div>
+      </a>
+
+      <a class="list-group-item list-group-item-action" href="#">
+        <div class="d-flex justify-content-between">
+          <h6>大野印刷株式会社</h6>
+          <small>TEL: 090-1157-4630</small>
+        </div>
+        <div class="d-flex justify-content-between">
+          <small>〒590-0928 東京都渋谷区神南1-2-1</small>
+          <small>FAX: 070-8662-0619</small>
+        </div>
+      </a>
+
+      <a class="list-group-item list-group-item-action" href="#">
+        <div class="d-flex justify-content-between">
+          <h6>佐々木食品株式会社</h6>
+          <small>TEL: 080-6616-2999</small>
+        </div>
+        <div class="d-flex justify-content-between">
+          <small>〒039-4152 東京都渋谷区神南1-2-2</small>
+          <small>FAX: 070-6702-6634</small>
+        </div>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="#">
+        <div class="d-flex justify-content-between">
+          <h6>合資会社山本印刷</h6>
+          <small>TEL: 090-3466-6784</small>
+        </div>
+        <div class="d-flex justify-content-between">
+          <small>〒479-0045 東京都渋谷区神南1-2-3</small>
+          <small>FAX: 080-6811-0656</small>
+        </div>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="#">
+        <div class="d-flex justify-content-between">
+          <h6>合名会社山田印刷</h6>
+          <small>TEL: 080-9274-1520</small>
+        </div>
+        <div class="d-flex justify-content-between">
+          <small>〒761-4423 東京都渋谷区神南1-2-4</small>
+          <small>FAX: 090-5827-2604</small>
+        </div>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="#">
+        <div class="d-flex justify-content-between">
+          <h6>金子農林合名会社</h6>
+          <small>TEL: 070-6909-6952</small>
+        </div>
+        <div class="d-flex justify-content-between">
+          <small>〒292-0801 東京都渋谷区神南1-2-5</small>
+          <small>FAX: 070-8503-0054</small>
+        </div>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="#">
+        <div class="d-flex justify-content-between">
+          <h6>合資会社杉山ガス</h6>
+          <small>TEL: 080-2228-3988</small>
+        </div>
+        <div class="d-flex justify-content-between">
+          <small>〒612-8484 東京都渋谷区神南1-2-6</small>
+          <small>FAX: 070-1981-8467</small>
+        </div>
+      </a>      
+    </div>
+
+    <ul class="pagination justify-content-center mb-5">
+      <li class="page-item disabled">
+        <a class="page-link">前のページ</a>
+      </li>
+      
+      <li class="page-item active">
+        <a class="page-link" href="#">1</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">2</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">3</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">4</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">5</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">6</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">7</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">8</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">9</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">10</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">11</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">12</a>
+      </li>
+      
+      <li class="page-item ">
+        <a class="page-link" href="#">13</a>
+      </li>
+      
+      <li class="page-item">
+        <a class="page-link" href="#">次のページ</a>
+      </li>
+    </ul>
+
+    <div class="d-flex justify-content-evenly">
+      <a href="#">メーカー情報の登録</a>
+      <a href="#">メインメニューへ</a>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -11,6 +11,7 @@ import CategoriesIndexView from '@/components/categories/CategoriesIndexView.vue
 import CategoriesShowView from './components/categories/CategoriesShowView.vue'
 import CategoriesNewView from './components/categories/CategoriesNewView.vue'
 import CategoriesEditView from './components/categories/CategoriesEditView.vue'
+import MakersIndexView from './components/makers/MakersIndexView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -26,6 +27,7 @@ const routes = [
   { path: '/categories/:id', component: CategoriesShowView },
   { path: '/categories/new', component: CategoriesNewView },
   { path: '/categories/:id/edit', component: CategoriesEditView },
+  { path: '/makers', component: MakersIndexView },
 ]
 
 const router = createRouter({

--- a/frontend/test/component/HomeView.test.js
+++ b/frontend/test/component/HomeView.test.js
@@ -68,7 +68,7 @@ describe('HomeView', () => {
       expect(links[3].attributes('href')).toBe('#')
       expect(links[4].attributes('href')).toBe('#')
       expect(links[5].attributes('href')).toBe('/categories')
-      expect(links[6].attributes('href')).toBe('#')
+      expect(links[6].attributes('href')).toBe('/makers')
       expect(links[7].attributes('href')).toBe('/users')
       expect(links[8].attributes('href')).toBe('/settings')
     })

--- a/frontend/test/component/makers/MakersIndexView.test.js
+++ b/frontend/test/component/makers/MakersIndexView.test.js
@@ -78,25 +78,9 @@ describe('MakersIndexView', () => {
             "phone_number": "090-6097-5063",
             "fax_number": "090-2418-6666",
           },
-          {
-            "id": 8,
-            "name": "杉山通信合名会社",
-            "postal_code": "781-4246",
-            "address": "東京都渋谷区神南1-2-7",
-            "phone_number": "080-1190-9863",
-            "fax_number": "070-1138-0025",
-          },
-          {
-            "id": 9,
-            "name": "藤本情報有限会社",
-            "postal_code": "014-1116",
-            "address": "東京都渋谷区神南1-2-8",
-            "phone_number": "080-5522-9216",
-            "fax_number": "070-2610-5760",
-          },
         ],
         current_page: 1,
-        total_pages: 2
+        total_pages: 1
       }
     }),
     wrapper = mount(MakersIndexView, {
@@ -120,39 +104,37 @@ describe('MakersIndexView', () => {
       expect(labels[1].text()).toBe('電話番号 / FAX番号')
     })
   
-    it('メーカーリストが9件表示されること', () => {
+    it('メーカーリストが7件表示されること', () => {
       const links = wrapper.findAll('a[class="list-group-item list-group-item-action"]')
 
-      expect(links.length).toBe(9)
+      expect(links.length).toBe(7)
     })
 
     it('ページネーションの「前ページ」と「次ページ」のリンクが表示されること', () => {
-      const spanElement = wrapper.find('span[class="page-link"]')
-      const aElement = wrapper.findAll('a[class="page-link"]')
+      const spanElement = wrapper.findAll('span[class="page-link"]')
 
-      expect(spanElement.text()).toBe('前ページ')
-      expect(aElement[2].text()).toBe('次ページ')
+      expect(spanElement[0].text()).toBe('前ページ')
+      expect(spanElement[1].text()).toBe('次ページ')
     })
 
-    it('total_pagesが2に対しページネーションリンクの「1」と「2」が表示されること', () => {
+    it('total_pagesが1に対しページネーションリンクの「1」が表示されること', () => {
       const aElement = wrapper.findAll('a[class="page-link"]')
 
       expect(aElement[0].text()).toBe('1')
-      expect(aElement[1].text()).toBe('2')
     })
 
     it('外部リンク「メーカー情報の登録」と「メインメニュー」が表示されること', () => {
       const links = wrapper.findAllComponents(RouterLinkStub)
 
-      expect(links[12].text()).toBe('メーカー情報の登録')
-      expect(links[13].text()).toBe('メインメニューへ')
+      expect(links[8].text()).toBe('メーカー情報の登録')
+      expect(links[9].text()).toBe('メインメニューへ')
     })
 
     it('外部リンクのto属性に「#」と「/home」が設定されていること', () => {
       const links = wrapper.findAllComponents(RouterLinkStub)
 
-      expect(links[12].props().to).toBe('#')
-      expect(links[13].props().to).toBe('/home')
+      expect(links[8].props().to).toBe('#')
+      expect(links[9].props().to).toBe('/home')
     })
   })  
 })

--- a/frontend/test/component/makers/MakersIndexView.test.js
+++ b/frontend/test/component/makers/MakersIndexView.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MakersIndexView from '@/components/makers/MakersIndexView.vue'
+
+describe('MakersIndexView', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(MakersIndexView)
+  })
+
+  describe('コンポーネントのレンダリング', () => {
+    it('見出し「メーカーリスト」が表示されること', () => {
+      expect(wrapper.find('h3').text()).toBe('メーカーリスト')
+    })
+  
+    it('ラベル「メーカー名 / 住所」と「電話番号 / FAX番号」が表示されること', () => {
+      const labels = wrapper.findAll('h6')
+  
+      expect(labels[0].text()).toBe('メーカー名 / 住所')
+      expect(labels[1].text()).toBe('電話番号 / FAX番号')
+    })
+  
+    it('ページネーションの「前のページ」と「次のページ」のリンクが表示されること', () => {
+      const links = wrapper.findAll('a[class="page-link"]')
+
+      expect(links[0].text()).toBe('前のページ')
+      expect(links[14].text()).toBe('次のページ')
+    })
+
+    it('外部リンク「メーカー情報の登録」と「メインメニュー」が表示されること', () => {
+      const links = wrapper.findAll('a')
+
+      expect(links[22].text()).toBe('メーカー情報の登録')
+      expect(links[23].text()).toBe('メインメニューへ')
+    })
+  })  
+})

--- a/frontend/test/component/makers/MakersIndexView.test.js
+++ b/frontend/test/component/makers/MakersIndexView.test.js
@@ -1,12 +1,111 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import MakersIndexView from '@/components/makers/MakersIndexView.vue'
+import axios from 'axios'
+
+vi.mock('axios')
+
+vi.mock('vue-router', () => {
+  return {
+    useRoute: () => {
+      return {
+        query: { page: '1' }
+      }
+    }
+  }
+})
 
 describe('MakersIndexView', () => {
   let wrapper
 
   beforeEach(() => {
-    wrapper = mount(MakersIndexView)
+    axios.get.mockResolvedValue({ 
+      data: { 
+        makers: [
+          {
+            "id": 1,
+            "name": "有限会社中野銀行",
+            "postal_code": "962-0713",
+            "address": "東京都渋谷区神南1-2-0",
+            "phone_number": "070-3288-2552",
+            "fax_number": "070-2623-8399",
+          },
+          {
+            "id": 2,
+            "name": "坂本建設有限会社",
+            "postal_code": "652-0812",
+            "address": "東京都渋谷区神南1-2-1",
+            "phone_number": "070-2977-0116",
+            "fax_number": "090-2701-9505",
+          },
+          {
+            "id": 3,
+            "name": "合同会社中村食品",
+            "postal_code": "950-2073",
+            "address": "東京都渋谷区神南1-2-2",
+            "phone_number": "080-3109-7360",
+            "fax_number": "070-2929-9663",
+          },
+          {
+            "id": 4,
+            "name": "合名会社武田印刷",
+            "postal_code": "007-0870",
+            "address": "東京都渋谷区神南1-2-3",
+            "phone_number": "080-7349-8615",
+            "fax_number": "080-3489-8988",
+          },
+          {
+            "id": 5,
+            "name": "中川食品有限会社",
+            "postal_code": "990-0810",
+            "address": "東京都渋谷区神南1-2-4",
+            "phone_number": "080-7508-7472",
+            "fax_number": "080-8725-9443",
+          },
+          {
+            "id": 6,
+            "name": "河野電気株式会社",
+            "postal_code": "780-0932",
+            "address": "東京都渋谷区神南1-2-5",
+            "phone_number": "070-6431-8311",
+            "fax_number": "080-1287-6419",
+          },
+          {
+            "id": 7,
+            "name": "小山食品合同会社",
+            "postal_code": "649-2602",
+            "address": "東京都渋谷区神南1-2-6",
+            "phone_number": "090-6097-5063",
+            "fax_number": "090-2418-6666",
+          },
+          {
+            "id": 8,
+            "name": "杉山通信合名会社",
+            "postal_code": "781-4246",
+            "address": "東京都渋谷区神南1-2-7",
+            "phone_number": "080-1190-9863",
+            "fax_number": "070-1138-0025",
+          },
+          {
+            "id": 9,
+            "name": "藤本情報有限会社",
+            "postal_code": "014-1116",
+            "address": "東京都渋谷区神南1-2-8",
+            "phone_number": "080-5522-9216",
+            "fax_number": "070-2610-5760",
+          },
+        ],
+        current_page: 1,
+        total_pages: 2
+      }
+    }),
+    wrapper = mount(MakersIndexView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
   })
 
   describe('コンポーネントのレンダリング', () => {
@@ -21,18 +120,32 @@ describe('MakersIndexView', () => {
       expect(labels[1].text()).toBe('電話番号 / FAX番号')
     })
   
-    it('ページネーションの「前のページ」と「次のページ」のリンクが表示されること', () => {
-      const links = wrapper.findAll('a[class="page-link"]')
+    it('メーカーリストが9件表示されること', () => {
+      const links = wrapper.findAll('a[class="list-group-item list-group-item-action"]')
 
-      expect(links[0].text()).toBe('前のページ')
-      expect(links[14].text()).toBe('次のページ')
+      expect(links.length).toBe(9)
+    })
+
+    it('ページネーションの「前ページ」と「次ページ」のリンクが表示されること', () => {
+      const spanElement = wrapper.find('span[class="page-link"]')
+      const aElement = wrapper.findAll('a[class="page-link"]')
+
+      expect(spanElement.text()).toBe('前ページ')
+      expect(aElement[2].text()).toBe('次ページ')
+    })
+
+    it('total_pagesが2に対しページネーションリンクの「1」と「2」が表示されること', () => {
+      const aElement = wrapper.findAll('a[class="page-link"]')
+
+      expect(aElement[0].text()).toBe('1')
+      expect(aElement[1].text()).toBe('2')
     })
 
     it('外部リンク「メーカー情報の登録」と「メインメニュー」が表示されること', () => {
       const links = wrapper.findAll('a')
 
-      expect(links[22].text()).toBe('メーカー情報の登録')
-      expect(links[23].text()).toBe('メインメニューへ')
+      expect(links[12].text()).toBe('メーカー情報の登録')
+      expect(links[13].text()).toBe('メインメニューへ')
     })
   })  
 })

--- a/frontend/test/component/makers/MakersIndexView.test.js
+++ b/frontend/test/component/makers/MakersIndexView.test.js
@@ -142,10 +142,17 @@ describe('MakersIndexView', () => {
     })
 
     it('外部リンク「メーカー情報の登録」と「メインメニュー」が表示されること', () => {
-      const links = wrapper.findAll('a')
+      const links = wrapper.findAllComponents(RouterLinkStub)
 
       expect(links[12].text()).toBe('メーカー情報の登録')
       expect(links[13].text()).toBe('メインメニューへ')
+    })
+
+    it('外部リンクのto属性に「#」と「/home」が設定されていること', () => {
+      const links = wrapper.findAllComponents(RouterLinkStub)
+
+      expect(links[12].props().to).toBe('#')
+      expect(links[13].props().to).toBe('/home')
     })
   })  
 })

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import App from '@/App.vue'
+import router from '@/router'
+
+describe('Makers routing', () => {
+  it('「メーカーリスト」ページに遷移できること', async () => {
+    router.push('/makers')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router]
+      }
+    })
+
+    expect(wrapper.html()).toContain('メーカーリスト')
+  })
+})


### PR DESCRIPTION
## 概要
Rails ビューの makers/index を Vue.js でリファインする。
コンポーネント名：MakersIndexView.vue
テスト名：MakersIndexView.test.js

## 実装
- [x] コンポーネント
- [x] ルーティング
- [x] レンダリングのテスト
- [x] ルーティングのテスト
- [x] josnデータの出力形式を変更
- [x] リクエスト・レスポンス
- [x] リクエスト・レスポンスのテスト
- [x] ページネーション設定
- [x] ページネーションのテスト
- [x] 外部リンク設定
- [x] 外部リンクのテスト
- [x] UI/UX の微調整
- [x] リファクタリング

## 改善点
- [x] per_page: を7か8に再調整