### PR TITLE
メーカーの新規登録機能

### DIFF
--- a/frontend/src/components/makers/MakersIndexView.vue
+++ b/frontend/src/components/makers/MakersIndexView.vue
@@ -77,7 +77,7 @@ onMounted(() => {
     </ul>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink to="#">メーカー情報の登録</RouterLink>
+      <RouterLink to="/makers/new">メーカー情報の登録</RouterLink>
       <RouterLink to="/home">メインメニューへ</RouterLink>
     </div>
   </div>

--- a/frontend/src/components/makers/MakersNewView.vue
+++ b/frontend/src/components/makers/MakersNewView.vue
@@ -66,7 +66,7 @@ const makerRegistration = async () => {
       <input v-model="homePage" class="form-control mb-2" type="url" id="maker_home_page" />
       
       <label class="form-label" for="maker_manufacturer_rep">担当者</label>
-      <input v-model="manufacturerRep" class="form-control mb-3" type="text" id="maker_manufacturer_rep" />
+      <input v-model="manufacturerRep" class="form-control mb-3" type="text" id="maker_manufacturer_rep"/>
       
       <button type="submit" class="form-control btn btn-primary mb-5">登録</button>
     </form>

--- a/frontend/src/components/makers/MakersNewView.vue
+++ b/frontend/src/components/makers/MakersNewView.vue
@@ -1,31 +1,72 @@
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+import router from '@/router'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const maker = ref('')
+const name = ref('')
+const postalCode = ref('')
+const address = ref('')
+const phoneNumber = ref('')
+const faxNumber = ref('')
+const email = ref('')
+const homePage = ref('')
+const manufacturerRep = ref('')
+const errorMessage = ref('')
+
+const makerRegistration = async () => {
+  try {
+    const response = await axios.post(`${API_BASE_URL}/makers`, {
+      maker: {
+        name: name.value,
+        postal_code: postalCode.value,
+        address: address.value,
+        phone_number: phoneNumber.value,
+        fax_number: faxNumber.value,
+        email: email.value,
+        home_page: homePage.value,
+        manufacturer_rep: manufacturerRep.value
+      }
+    })
+    maker.value = response.data
+    router.push(`/makers/${maker.value.id}`)
+  } catch (error) {
+    errorMessage.value = '入力に不備があります。'
+  }
+}
+</script>
+
 <template>
   <div class="container w-25">
     <h3 class="text-center mt-5 mb-5">メーカー情報の登録</h3>
 
-    <form action="/makers" accept-charset="UTF-8" method="post"><input type="hidden" name="authenticity_token" value="oBb2XYLck14ar9-bRmlv-2fFNBuu0-QvMb7CqBlFCLOAqrRsRvtJ3-MpYUaGO2US8jbJcCFiI_68xy04N3Inug" autocomplete="off" />
+    <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
+
+    <form v-on:submit.prevent="makerRegistration">
       <label class="form-label" for="maker_name">メーカー名</label>
-      <input class="form-control mb-2" type="text" name="maker[name]" id="maker_name" />
+      <input v-model="name" class="form-control mb-2" type="text" id="maker_name" />
       
       <label class="form-label" for="maker_postal_code">郵便番号</label>
-      <input class="form-control mb-2" style="width: 10rem;" type="text" name="maker[postal_code]" id="maker_postal_code" />
+      <input v-model="postalCode" class="form-control mb-2" style="width: 10rem;" type="text" id="maker_postal_code" />
       
       <label class="form-label" for="maker_address">住所</label>
-      <input class="form-control mb-2" type="text" name="maker[address]" id="maker_address" />
+      <input v-model="address" class="form-control mb-2" type="text" id="maker_address" />
       
       <label class="form-label" for="maker_phone_number">電話番号</label>
-      <input class="form-control mb-2" style="width: 10rem;" type="tel" name="maker[phone_number]" id="maker_phone_number" />
+      <input v-model="phoneNumber" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_phone_number" />
       
       <label class="form-label" for="maker_fax_number">FAX番号</label>
-      <input class="form-control mb-2" style="width: 10rem;" type="tel" name="maker[fax_number]" id="maker_fax_number" />
+      <input v-model="faxNumber" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_fax_number" />
       
       <label class="form-label" for="maker_email">Email</label>
-      <input class="form-control mb-2" type="email" name="maker[email]" id="maker_email" />
+      <input v-model="email" class="form-control mb-2" type="email" id="maker_email" />
       
       <label class="form-label" for="maker_home_page">ホームページ</label>
-      <input class="form-control mb-2" type="url" name="maker[home_page]" id="maker_home_page" />
+      <input v-model="homePage" class="form-control mb-2" type="url" id="maker_home_page" />
       
       <label class="form-label" for="maker_manufacturer_rep">担当者</label>
-      <input class="form-control mb-3" type="text" name="maker[manufacturer_rep]" id="maker_manufacturer_rep" />
+      <input v-model="manufacturerRep" class="form-control mb-3" type="text" id="maker_manufacturer_rep" />
       
       <button type="submit" class="form-control btn btn-primary mb-5">登録</button>
     </form>

--- a/frontend/src/components/makers/MakersNewView.vue
+++ b/frontend/src/components/makers/MakersNewView.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="container w-25">
+    <h3 class="text-center mt-5 mb-5">メーカー情報の登録</h3>
+
+    <form action="/makers" accept-charset="UTF-8" method="post"><input type="hidden" name="authenticity_token" value="oBb2XYLck14ar9-bRmlv-2fFNBuu0-QvMb7CqBlFCLOAqrRsRvtJ3-MpYUaGO2US8jbJcCFiI_68xy04N3Inug" autocomplete="off" />
+      <label class="form-label" for="maker_name">メーカー名</label>
+      <input class="form-control mb-2" type="text" name="maker[name]" id="maker_name" />
+      
+      <label class="form-label" for="maker_postal_code">郵便番号</label>
+      <input class="form-control mb-2" style="width: 10rem;" type="text" name="maker[postal_code]" id="maker_postal_code" />
+      
+      <label class="form-label" for="maker_address">住所</label>
+      <input class="form-control mb-2" type="text" name="maker[address]" id="maker_address" />
+      
+      <label class="form-label" for="maker_phone_number">電話番号</label>
+      <input class="form-control mb-2" style="width: 10rem;" type="tel" name="maker[phone_number]" id="maker_phone_number" />
+      
+      <label class="form-label" for="maker_fax_number">FAX番号</label>
+      <input class="form-control mb-2" style="width: 10rem;" type="tel" name="maker[fax_number]" id="maker_fax_number" />
+      
+      <label class="form-label" for="maker_email">Email</label>
+      <input class="form-control mb-2" type="email" name="maker[email]" id="maker_email" />
+      
+      <label class="form-label" for="maker_home_page">ホームページ</label>
+      <input class="form-control mb-2" type="url" name="maker[home_page]" id="maker_home_page" />
+      
+      <label class="form-label" for="maker_manufacturer_rep">担当者</label>
+      <input class="form-control mb-3" type="text" name="maker[manufacturer_rep]" id="maker_manufacturer_rep" />
+      
+      <button type="submit" class="form-control btn btn-primary mb-5">登録</button>
+    </form>
+
+    <div class="d-flex justify-content-center">
+      <a href="/makers">メーカーリストへ</a>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/makers/MakersNewView.vue
+++ b/frontend/src/components/makers/MakersNewView.vue
@@ -45,7 +45,7 @@ const makerRegistration = async () => {
 
     <form v-on:submit.prevent="makerRegistration">
       <label class="form-label" for="maker_name">メーカー名</label>
-      <input v-model="name" class="form-control mb-2" type="text" id="maker_name" />
+      <input v-model="name" class="form-control mb-2" type="text" id="maker_name" required/>
       
       <label class="form-label" for="maker_postal_code">郵便番号</label>
       <input v-model="postalCode" class="form-control mb-2" style="width: 10rem;" type="text" id="maker_postal_code" />

--- a/frontend/src/components/makers/MakersNewView.vue
+++ b/frontend/src/components/makers/MakersNewView.vue
@@ -72,7 +72,7 @@ const makerRegistration = async () => {
     </form>
 
     <div class="d-flex justify-content-center">
-      <a href="/makers">メーカーリストへ</a>
+      <RouterLink to="/makers">メーカーリストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -13,10 +13,11 @@ import CategoriesNewView from './components/categories/CategoriesNewView.vue'
 import CategoriesEditView from './components/categories/CategoriesEditView.vue'
 import MakersIndexView from './components/makers/MakersIndexView.vue'
 import MakersShowView from './components/makers/MakersShowView.vue'
+import MakersNewView from './components/makers/MakersNewView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
-const routes = [   
+const routes = [
   { path: '/', component: LoginForm },
   { path: '/home', component: HomeView },
   { path: '/settings', component: SettingsView },
@@ -30,6 +31,7 @@ const routes = [
   { path: '/categories/:id/edit', component: CategoriesEditView },
   { path: '/makers', component: MakersIndexView },
   { path: '/makers/:id', component: MakersShowView },
+  { path: '/makers/new', component: MakersNewView },
 ]
 
 const router = createRouter({

--- a/frontend/test/component/makers/MakersIndexView.test.js
+++ b/frontend/test/component/makers/MakersIndexView.test.js
@@ -133,7 +133,7 @@ describe('MakersIndexView', () => {
     it('外部リンクのto属性に「#」と「/home」が設定されていること', () => {
       const links = wrapper.findAllComponents(RouterLinkStub)
 
-      expect(links[8].props().to).toBe('#')
+      expect(links[8].props().to).toBe('/makers/new')
       expect(links[9].props().to).toBe('/home')
     })
   })  

--- a/frontend/test/component/makers/MakersNewView.test.js
+++ b/frontend/test/component/makers/MakersNewView.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MakersNewView from '@/components/makers/MakersNewView.vue'
+
+describe('MakersNewView', () => {
+  it('見出しが表示されること', () => {
+    const wrapper = mount(MakersNewView)
+
+    expect(wrapper.find('h3').text()).toBe('メーカー情報の登録')
+  })
+
+  it('入力フォームが表示されること', () => {
+    const wrapper = mount(MakersNewView)
+
+    expect(wrapper.find('form').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_name"]').text()).toBe('メーカー名')
+    expect(wrapper.find('input[id="maker_name"]').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_postal_code"]').text()).toBe('郵便番号')
+    expect(wrapper.find('input[id="maker_postal_code"]').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_address"]').text()).toBe('住所')
+    expect(wrapper.find('input[id="maker_address"]').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_phone_number"]').text()).toBe('電話番号')
+    expect(wrapper.find('input[id="maker_phone_number"]').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_fax_number"]').text()).toBe('FAX番号')
+    expect(wrapper.find('input[id="maker_fax_number"]').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_email"]').text()).toBe('Email')
+    expect(wrapper.find('input[id="maker_email"]').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_home_page"]').text()).toBe('ホームページ')
+    expect(wrapper.find('input[id="maker_home_page"]').exists()).toBe(true)
+
+    expect(wrapper.find('label[for="maker_manufacturer_rep"]').text()).toBe('担当者')
+    expect(wrapper.find('input[id="maker_manufacturer_rep"]').exists()).toBe(true)
+
+    expect(wrapper.find('button').exists()).toBe(true)
+  })
+
+  it('外部リンクが表示されること', () => {
+    const wrapper = mount(MakersNewView)
+
+    expect(wrapper.find('a').text()).toBe('メーカーリストへ')
+  })
+})

--- a/frontend/test/component/makers/MakersNewView.test.js
+++ b/frontend/test/component/makers/MakersNewView.test.js
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import MakersNewView from '@/components/makers/MakersNewView.vue'
+import axios from 'axios'
+import router from '@/router'
+
+vi.mock('axios')
+
+vi.mock('@/router', () => {
+  return {
+    default: {
+      push: vi.fn()
+    }
+  }
+})
 
 describe('MakersNewView', () => {
   it('見出しが表示されること', () => {
@@ -45,5 +57,57 @@ describe('MakersNewView', () => {
     const wrapper = mount(MakersNewView)
 
     expect(wrapper.find('a').text()).toBe('メーカーリストへ')
+  })
+
+  it('有効な情報を入力した場合は登録が成功すること', async () => {
+    const mockMaker = {
+      data: {
+        maker: {
+          name: "有限会社中野銀行",
+          postal_code: "962-0713",
+          address: "東京都渋谷区神南1-2-0",
+          phone_number: "070-3288-2552",
+          fax_number: "070-2623-8399",
+          email: "sample_maker0@example.com",
+          home_page: "https://example.com/sample_maker0",
+          manufacturer_rep: "宮本 悠斗"
+        }
+      }
+    }
+
+    axios.post.mockResolvedValue(mockMaker)
+
+    const wrapper = mount(MakersNewView)
+
+    const nameInput = wrapper.find('input[id="maker_name"]')
+    const postalCodeInput = wrapper.find('input[id="maker_postal_code"]')
+    const addressInput = wrapper.find('input[id="maker_address"]')
+    const phoneNumberInput = wrapper.find('input[id="maker_phone_number"]')
+    const faxNumberInput = wrapper.find('input[id="maker_fax_number"]')
+    const emailInput = wrapper.find('input[id="maker_email"]')
+    const homePageInput = wrapper.find('input[id="maker_home_page"]')
+    const manufacturerRepInput = wrapper.find('input[id="maker_manufacturer_rep"]')
+    
+    await nameInput.setValue('有限会社中野銀行')
+    await postalCodeInput.setValue('962-0713')
+    await addressInput.setValue('東京都渋谷区神南1-2-0')
+    await phoneNumberInput.setValue('070-3288-2552')
+    await faxNumberInput.setValue('070-2623-8399')
+    await emailInput.setValue('sample_maker0@example.com')
+    await homePageInput.setValue('https://example.com/sample_maker0')
+    await manufacturerRepInput.setValue('宮本 悠斗')
+    await wrapper.find('form').trigger('submit.prevent')
+
+    expect(router.push).toHaveBeenCalledWith(`/makers/${mockMaker.id}`)
+  })
+
+  it('無効な情報を入力した場合は登録が失敗すること', async () => {
+    axios.post.mockRejectedValue(new Error('Invalid credentials'))
+
+    const wrapper = mount(MakersNewView)
+
+    await wrapper.find('form').trigger('submit.prevent')
+
+    expect(wrapper.text()).toContain('入力に不備があります。')
   })
 })

--- a/frontend/test/component/makers/MakersNewView.test.js
+++ b/frontend/test/component/makers/MakersNewView.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import MakersNewView from '@/components/makers/MakersNewView.vue'
 import axios from 'axios'
 import router from '@/router'
@@ -54,9 +54,16 @@ describe('MakersNewView', () => {
   })
 
   it('外部リンクが表示されること', () => {
-    const wrapper = mount(MakersNewView)
+    const wrapper = mount(MakersNewView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
 
-    expect(wrapper.find('a').text()).toBe('メーカーリストへ')
+    expect(wrapper.findComponent(RouterLinkStub).text()).toBe('メーカーリストへ')
+    expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/makers')
   })
 
   it('有効な情報を入力した場合は登録が成功すること', async () => {

--- a/frontend/test/component/makers/MakersNewView.test.js
+++ b/frontend/test/component/makers/MakersNewView.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import MakersNewView from '@/components/makers/MakersNewView.vue'
 import axios from 'axios'
 import router from '@/router'
@@ -15,106 +15,104 @@ vi.mock('@/router', () => {
 })
 
 describe('MakersNewView', () => {
-  it('見出しが表示されること', () => {
-    const wrapper = mount(MakersNewView)
+  let wrapper
 
-    expect(wrapper.find('h3').text()).toBe('メーカー情報の登録')
-  })
-
-  it('入力フォームが表示されること', () => {
-    const wrapper = mount(MakersNewView)
-
-    expect(wrapper.find('form').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_name"]').text()).toBe('メーカー名')
-    expect(wrapper.find('input[id="maker_name"]').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_postal_code"]').text()).toBe('郵便番号')
-    expect(wrapper.find('input[id="maker_postal_code"]').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_address"]').text()).toBe('住所')
-    expect(wrapper.find('input[id="maker_address"]').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_phone_number"]').text()).toBe('電話番号')
-    expect(wrapper.find('input[id="maker_phone_number"]').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_fax_number"]').text()).toBe('FAX番号')
-    expect(wrapper.find('input[id="maker_fax_number"]').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_email"]').text()).toBe('Email')
-    expect(wrapper.find('input[id="maker_email"]').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_home_page"]').text()).toBe('ホームページ')
-    expect(wrapper.find('input[id="maker_home_page"]').exists()).toBe(true)
-
-    expect(wrapper.find('label[for="maker_manufacturer_rep"]').text()).toBe('担当者')
-    expect(wrapper.find('input[id="maker_manufacturer_rep"]').exists()).toBe(true)
-
-    expect(wrapper.find('button').exists()).toBe(true)
-  })
-
-  it('外部リンクが表示されること', () => {
-    const wrapper = mount(MakersNewView, {
+  beforeEach(() => {
+    wrapper = mount(MakersNewView, {
       global: {
         stubs: {
           RouterLink: RouterLinkStub
         }
       }
     })
-
-    expect(wrapper.findComponent(RouterLinkStub).text()).toBe('メーカーリストへ')
-    expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/makers')
   })
 
-  it('有効な情報を入力した場合は登録が成功すること', async () => {
-    const mockMaker = {
-      data: {
-        maker: {
-          name: "有限会社中野銀行",
-          postal_code: "962-0713",
-          address: "東京都渋谷区神南1-2-0",
-          phone_number: "070-3288-2552",
-          fax_number: "070-2623-8399",
-          email: "sample_maker0@example.com",
-          home_page: "https://example.com/sample_maker0",
-          manufacturer_rep: "宮本 悠斗"
+  describe('初期レンダリング', () => {
+    it('見出しが表示されること', () => {
+      expect(wrapper.find('h3').text()).toBe('メーカー情報の登録')
+    })
+
+    it('フォームが存在すること', () => {
+      expect(wrapper.find('form').exists()).toBe(true)
+    })
+
+    it('すべてのラベルが表示されること', () => {
+      expect(wrapper.find('label[for="maker_name"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_name"]').text()).toBe('メーカー名')
+  
+      expect(wrapper.find('label[for="maker_postal_code"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_postal_code"]').text()).toBe('郵便番号')
+  
+      expect(wrapper.find('label[for="maker_address"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_address"]').text()).toBe('住所')
+  
+      expect(wrapper.find('label[for="maker_phone_number"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_phone_number"]').text()).toBe('電話番号')
+  
+      expect(wrapper.find('label[for="maker_fax_number"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_fax_number"]').text()).toBe('FAX番号')
+  
+      expect(wrapper.find('label[for="maker_email"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_email"]').text()).toBe('Email')
+  
+      expect(wrapper.find('label[for="maker_home_page"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_home_page"]').text()).toBe('ホームページ')
+  
+      expect(wrapper.find('label[for="maker_manufacturer_rep"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_manufacturer_rep"]').text()).toBe('担当者')
+    })
+
+    it('すべてのフォームフィールドが表示されること', () => {
+      expect(wrapper.find('input[id="maker_name"]').exists()).toBe(true)
+      expect(wrapper.find('input[id="maker_postal_code"]').exists()).toBe(true)
+      expect(wrapper.find('input[id="maker_address"]').exists()).toBe(true)
+      expect(wrapper.find('input[id="maker_phone_number"]').exists()).toBe(true)
+      expect(wrapper.find('input[id="maker_fax_number"]').exists()).toBe(true)
+      expect(wrapper.find('input[id="maker_email"]').exists()).toBe(true)
+      expect(wrapper.find('input[id="maker_home_page"]').exists()).toBe(true)
+      expect(wrapper.find('input[id="maker_manufacturer_rep"]').exists()).toBe(true)
+    })
+
+    it('登録ボタンが表示されること', () => {
+      expect(wrapper.find('button').exists()).toBe(true)
+      expect(wrapper.find('button').text()).toBe('登録')
+    })
+
+    it('外部リンクが表示されること', () => {
+      expect(wrapper.findComponent(RouterLinkStub).text()).toBe('メーカーリストへ')
+      expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/makers')
+    })
+  })
+  
+  describe('API通信', () => {
+    describe('有効な情報を送信すると、', () => {
+      it('登録が成功すること', async () => {
+        const mockResponse = {
+          data: {
+            id: 1,
+            name: '株式会社テスト',
+          }
         }
-      }
-    }
+      
+        axios.post.mockResolvedValue(mockResponse)
+        
+        await wrapper.find('form').trigger('submit.prevent')
+        await flushPromises()
+  
+        expect(axios.post).toHaveBeenCalled()
+        expect(router.push).toHaveBeenCalledWith('/makers/1')
+      })
+    })
 
-    axios.post.mockResolvedValue(mockMaker)
-
-    const wrapper = mount(MakersNewView)
-
-    const nameInput = wrapper.find('input[id="maker_name"]')
-    const postalCodeInput = wrapper.find('input[id="maker_postal_code"]')
-    const addressInput = wrapper.find('input[id="maker_address"]')
-    const phoneNumberInput = wrapper.find('input[id="maker_phone_number"]')
-    const faxNumberInput = wrapper.find('input[id="maker_fax_number"]')
-    const emailInput = wrapper.find('input[id="maker_email"]')
-    const homePageInput = wrapper.find('input[id="maker_home_page"]')
-    const manufacturerRepInput = wrapper.find('input[id="maker_manufacturer_rep"]')
-    
-    await nameInput.setValue('有限会社中野銀行')
-    await postalCodeInput.setValue('962-0713')
-    await addressInput.setValue('東京都渋谷区神南1-2-0')
-    await phoneNumberInput.setValue('070-3288-2552')
-    await faxNumberInput.setValue('070-2623-8399')
-    await emailInput.setValue('sample_maker0@example.com')
-    await homePageInput.setValue('https://example.com/sample_maker0')
-    await manufacturerRepInput.setValue('宮本 悠斗')
-    await wrapper.find('form').trigger('submit.prevent')
-
-    expect(router.push).toHaveBeenCalledWith(`/makers/${mockMaker.id}`)
-  })
-
-  it('無効な情報を入力した場合は登録が失敗すること', async () => {
-    axios.post.mockRejectedValue(new Error('Invalid credentials'))
-
-    const wrapper = mount(MakersNewView)
-
-    await wrapper.find('form').trigger('submit.prevent')
-
-    expect(wrapper.text()).toContain('入力に不備があります。')
-  })
+    describe('空の状態で送信すると、', () => {
+      it('登録が失敗すること', async () => {
+        axios.post.mockRejectedValue(new Error('バリデーションエラー'))
+        
+        await wrapper.find('form').trigger('submit.prevent')
+        await flushPromises()
+      
+        expect(wrapper.text()).toContain('入力に不備があります。')
+      })
+    })
+  })  
 })

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -31,4 +31,18 @@ describe('Makers routing', () => {
 
     expect(wrapper.html()).toContain('メーカー情報')
   })
+
+  it('「メーカー情報の新規登録」ページに遷移すること', async () => {
+    router.push('makers/new')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router]
+      }
+    })
+
+    expect(wrapper.html()).toContain('メーカー情報の登録')
+  })
 })


### PR DESCRIPTION
## 概要
Rails ビューの makers/new を Vue.js でリファインする。
コンポーネント名：MakersNewView.vue
テスト名：MakersNewView.test.js

## 実装
- [x] コンポーネント
- [x] ルーティング
- [x] コンポーネントのテスト
- [x] ルーティングのテスト
- [x] リクエスト・レスポンス
- [x] リクエスト・レスポンスのテスト
- [x] 外部リンク設定
- [x] 外部リンクのテスト
- [x] UI/UX の微調整
- [x] 改善事項

## 改善事項
- テスト
  - [x] 有効・無効な情報を入力したときのテストコード見直し
  - [x] 警告「Failed to resolve component: RouterLink」の解消
  - [x] describe の構造見直し

## 参考文献
- [VitestでMockを使うための逆引きレシピ集](https://zenn.dev/yskn_sid25/articles/a5a22aa43aa46b)