### PR TITLE
メーカーの編集機能

### DIFF
--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 const router = useRouter()
 
 function goHome() {
-  router.push('/')
+  router.push('/home')
 }
 </script>
 
@@ -13,6 +13,6 @@ function goHome() {
     <h1 class="mt-5 mb-5">404</h1>
     <p>お探しのページは見つかりませんでした。</p>
     <p>存在しないURLか、移動された可能性があります。</p>
-    <button class="mt-5" v-on:click="goHome">ホームに戻る</button>
+    <button class="btn btn-outline-primary mt-5" v-on:click="goHome">ホームに戻る</button>
   </div>
 </template>

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+function goHome() {
+  router.push('/')
+}
+</script>
+
+<template>
+  <div class="container text-center w-50">
+    <h1 class="mt-5 mb-5">404</h1>
+    <p>お探しのページは見つかりませんでした。</p>
+    <p>存在しないURLか、移動された可能性があります。</p>
+    <button class="mt-5" v-on:click="goHome">ホームに戻る</button>
+  </div>
+</template>

--- a/frontend/src/components/makers/MakersEditView.vue
+++ b/frontend/src/components/makers/MakersEditView.vue
@@ -1,42 +1,77 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import axios from 'axios'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const route = useRoute()
+const router = useRouter()
+const maker = ref('')
+const errorMessage = ref('')
+
+const fetchMakerData = async (id) => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/makers/${id}`)
+    maker.value = response.data
+  } catch (error) {
+    console.error('Get maker data failed')
+  }
+}
+
+const makerUpdate = async () => {
+  try {
+    const response = await axios.patch(`${API_BASE_URL}/makers/${maker.value.id}`, {
+      name: maker.value.name,
+      postal_code: maker.value.postal_code,
+      address: maker.value.address,
+      phone_number: maker.value.phone_number,
+      fax_number: maker.value.fax_number,
+      email: maker.value.email,
+      home_page: maker.value.home_page,
+      manufacturer_rep: maker.value.manufacturer_rep
+    })
+    maker.value = response.data
+    router.push(`/makers/${maker.value.id}`)
+  } catch (error) {
+    errorMessage.value = '入力に不備があります。'
+  }
+}
+
+onMounted(() => {
+  fetchMakerData(route.params.id)
+})
+</script>
+
 <template>
   <div class="container w-25">
     <h3 class="text-center mt-5 mb-5">メーカー情報の編集</h3>
 
-    <!-- <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p> -->
+    <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
 
-    <!-- <form v-on:submit.prevent="makerRegistration"> -->
-    <form>
+    <form v-on:submit.prevent="makerUpdate">
       <label class="form-label" for="maker_name">メーカー名</label>
-      <!-- <input v-model="name" class="form-control mb-2" type="text" id="maker_name" required/> -->
-      <input class="form-control mb-2" type="text" id="maker_name"/>
+      <input v-model="maker.name" class="form-control mb-2" type="text" id="maker_name" />
       
       <label class="form-label" for="maker_postal_code">郵便番号</label>
-      <!-- <input v-model="postalCode" class="form-control mb-2" style="width: 10rem;" type="text" id="maker_postal_code" /> -->
-      <input class="form-control mb-2" style="width: 10rem;" type="text" id="maker_postal_code" />
+      <input v-model="maker.postal_code" class="form-control mb-2" style="width: 10rem;" type="text" id="maker_postal_code" />
       
       <label class="form-label" for="maker_address">住所</label>
-      <!-- <input v-model="address" class="form-control mb-2" type="text" id="maker_address" /> -->
-      <input class="form-control mb-2" type="text" id="maker_address" />
+      <input v-model="maker.address" class="form-control mb-2" type="text" id="maker_address" />
       
       <label class="form-label" for="maker_phone_number">電話番号</label>
-      <!-- <input v-model="phoneNumber" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_phone_number" /> -->
-      <input class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_phone_number" />
+      <input v-model="maker.phone_number" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_phone_number" />
       
       <label class="form-label" for="maker_fax_number">FAX番号</label>
-      <!-- <input v-model="faxNumber" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_fax_number" /> -->
-      <input class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_fax_number" />
+      <input v-model="maker.fax_number" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_fax_number" />
       
       <label class="form-label" for="maker_email">Email</label>
-      <!-- <input v-model="email" class="form-control mb-2" type="email" id="maker_email" /> -->
-      <input class="form-control mb-2" type="email" id="maker_email" />
+      <input v-model="maker.email" class="form-control mb-2" type="email" id="maker_email" />
       
       <label class="form-label" for="maker_home_page">ホームページ</label>
-      <!-- <input v-model="homePage" class="form-control mb-2" type="url" id="maker_home_page" /> -->
-      <input class="form-control mb-2" type="url" id="maker_home_page" />
+      <input v-model="maker.home_page" class="form-control mb-2" type="url" id="maker_home_page" />
       
       <label class="form-label" for="maker_manufacturer_rep">担当者</label>
-      <!-- <input v-model="manufacturerRep" class="form-control mb-3" type="text" id="maker_manufacturer_rep"/> -->
-      <input class="form-control mb-3" type="text" id="maker_manufacturer_rep"/>
+      <input v-model="maker.manufacturer_rep" class="form-control mb-3" type="text" id="maker_manufacturer_rep"/>
       
       <button type="submit" class="form-control btn btn-primary mb-5">更新</button>
     </form>

--- a/frontend/src/components/makers/MakersEditView.vue
+++ b/frontend/src/components/makers/MakersEditView.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="container w-25">
+    <h3 class="text-center mt-5 mb-5">メーカー情報の編集</h3>
+
+    <!-- <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p> -->
+
+    <!-- <form v-on:submit.prevent="makerRegistration"> -->
+    <form>
+      <label class="form-label" for="maker_name">メーカー名</label>
+      <!-- <input v-model="name" class="form-control mb-2" type="text" id="maker_name" required/> -->
+      <input class="form-control mb-2" type="text" id="maker_name"/>
+      
+      <label class="form-label" for="maker_postal_code">郵便番号</label>
+      <!-- <input v-model="postalCode" class="form-control mb-2" style="width: 10rem;" type="text" id="maker_postal_code" /> -->
+      <input class="form-control mb-2" style="width: 10rem;" type="text" id="maker_postal_code" />
+      
+      <label class="form-label" for="maker_address">住所</label>
+      <!-- <input v-model="address" class="form-control mb-2" type="text" id="maker_address" /> -->
+      <input class="form-control mb-2" type="text" id="maker_address" />
+      
+      <label class="form-label" for="maker_phone_number">電話番号</label>
+      <!-- <input v-model="phoneNumber" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_phone_number" /> -->
+      <input class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_phone_number" />
+      
+      <label class="form-label" for="maker_fax_number">FAX番号</label>
+      <!-- <input v-model="faxNumber" class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_fax_number" /> -->
+      <input class="form-control mb-2" style="width: 10rem;" type="tel" id="maker_fax_number" />
+      
+      <label class="form-label" for="maker_email">Email</label>
+      <!-- <input v-model="email" class="form-control mb-2" type="email" id="maker_email" /> -->
+      <input class="form-control mb-2" type="email" id="maker_email" />
+      
+      <label class="form-label" for="maker_home_page">ホームページ</label>
+      <!-- <input v-model="homePage" class="form-control mb-2" type="url" id="maker_home_page" /> -->
+      <input class="form-control mb-2" type="url" id="maker_home_page" />
+      
+      <label class="form-label" for="maker_manufacturer_rep">担当者</label>
+      <!-- <input v-model="manufacturerRep" class="form-control mb-3" type="text" id="maker_manufacturer_rep"/> -->
+      <input class="form-control mb-3" type="text" id="maker_manufacturer_rep"/>
+      
+      <button type="submit" class="form-control btn btn-primary mb-5">更新</button>
+    </form>
+
+    <div class="d-flex justify-content-center">
+      <!-- <RouterLink to="/makers">メーカーリストへ</RouterLink> -->
+      <a>メーカーリストへ</a>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/makers/MakersEditView.vue
+++ b/frontend/src/components/makers/MakersEditView.vue
@@ -14,7 +14,9 @@ const fetchMakerData = async (id) => {
     const response = await axios.get(`${API_BASE_URL}/makers/${id}`)
     maker.value = response.data
   } catch (error) {
-    console.error('Get maker data failed')
+    if (error.response && error.response.status === 404) {
+      router.replace({ name: 'NotFound' })
+    }
   }
 }
 

--- a/frontend/src/components/makers/MakersEditView.vue
+++ b/frontend/src/components/makers/MakersEditView.vue
@@ -76,9 +76,9 @@ onMounted(() => {
       <button type="submit" class="form-control btn btn-primary mb-5">更新</button>
     </form>
 
-    <div class="d-flex justify-content-center">
-      <!-- <RouterLink to="/makers">メーカーリストへ</RouterLink> -->
-      <a>メーカーリストへ</a>
+    <div class="d-flex justify-content-evenly">
+      <RouterLink v-bind:to="`/makers/${maker.id}`" id="maker_information">メーカー情報へ</RouterLink>
+      <RouterLink to="/makers" id="maker_list">メーカーリストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/makers/MakersShowView.vue
+++ b/frontend/src/components/makers/MakersShowView.vue
@@ -72,7 +72,7 @@ onMounted(() => {
       </div>
 
       <div class="d-flex justify-content-evenly">
-        <RouterLink to="#" id="maker-edit">メーカー情報の編集へ</RouterLink>
+        <RouterLink v-if="maker.id" v-bind:to="`/makers/${maker.id}/edit`" id="maker-edit">メーカー情報の編集へ</RouterLink>
         <RouterLink to="#" id="maker-destroy">メーカー情報の削除</RouterLink>
         <RouterLink to="/makers" id="maker-list">メーカーリストへ</RouterLink>
       </div>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -15,6 +15,7 @@ import MakersIndexView from './components/makers/MakersIndexView.vue'
 import MakersShowView from './components/makers/MakersShowView.vue'
 import MakersNewView from './components/makers/MakersNewView.vue'
 import MakersEditView from './components/makers/MakersEditView.vue'
+import NotFound from './components/NotFound.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -34,6 +35,7 @@ const routes = [
   { path: '/makers/:id', component: MakersShowView },
   { path: '/makers/new', component: MakersNewView },
   { path: '/makers/:id/edit', component: MakersEditView },
+  { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound}
 ]
 
 const router = createRouter({

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -14,6 +14,7 @@ import CategoriesEditView from './components/categories/CategoriesEditView.vue'
 import MakersIndexView from './components/makers/MakersIndexView.vue'
 import MakersShowView from './components/makers/MakersShowView.vue'
 import MakersNewView from './components/makers/MakersNewView.vue'
+import MakersEditView from './components/makers/MakersEditView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -32,6 +33,7 @@ const routes = [
   { path: '/makers', component: MakersIndexView },
   { path: '/makers/:id', component: MakersShowView },
   { path: '/makers/new', component: MakersNewView },
+  { path: '/makers/:id/edit', component: MakersEditView },
 ]
 
 const router = createRouter({

--- a/frontend/test/component/makers/MakersEditView.test.js
+++ b/frontend/test/component/makers/MakersEditView.test.js
@@ -30,7 +30,7 @@ vi.mock('vue-router', async () => {
 describe('MakersEditView', () => {
   let wrapper
 
-  describe('初期レンダリング', () => {
+  describe('DOMの構造', () => {
     axios.get.mockResolvedValue({
       data: {
         id: 1,
@@ -55,15 +55,15 @@ describe('MakersEditView', () => {
       })
     })
 
-    it('見出しが表示されること', () => {
+    it('見出しが存在すること', () => {
       expect(wrapper.find('h3').text()).toBe('メーカー情報の編集')
     })
 
-    it('フォームが表示されること', () => {
+    it('フォームが存在すること', () => {
       expect(wrapper.find('form').exists()).toBe(true)
     })
 
-    it('すべてのラベルが表示されること', () => {
+    it('ラベルが存在すること', () => {
       expect(wrapper.find('label[for="maker_name"]').exists()).toBe(true)
       expect(wrapper.find('label[for="maker_name"]').text()).toBe('メーカー名')
 
@@ -89,7 +89,7 @@ describe('MakersEditView', () => {
       expect(wrapper.find('label[for="maker_manufacturer_rep"]').text()).toBe('担当者')
     })
 
-    it('すべてのフォームフィールドが表示されること', () => {
+    it('フォームフィールドが存在すること', () => {
       expect(wrapper.find('#maker_name').exists()).toBe(true)
       expect(wrapper.find('#maker_postal_code').exists()).toBe(true)
       expect(wrapper.find('#maker_address').exists()).toBe(true)
@@ -100,12 +100,12 @@ describe('MakersEditView', () => {
       expect(wrapper.find('#maker_manufacturer_rep').exists()).toBe(true)
     })
 
-    it('ボタンが表示されること', () => {
+    it('ボタンが存在すること', () => {
       expect(wrapper.find('button').exists()).toBe(true)
       expect(wrapper.find('button').text()).toBe('更新')
     })
 
-    it('外部リンクが表示されること', () => {
+    it('外部リンクが存在すること', () => {
       expect(wrapper.findComponent('#maker_information').text()).toBe('メーカー情報へ')
       expect(wrapper.findComponent('#maker_information').props().to).toBe('/makers/1')
 
@@ -171,7 +171,7 @@ describe('MakersEditView', () => {
         })
 
         await flushPromises()
-        
+
         expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
       })
     })
@@ -182,10 +182,31 @@ describe('MakersEditView', () => {
           data: {
             id: 1,
             name: "有限会社中野銀行",
+            postal_code: "962-0713",
+            address: "東京都渋谷区神南1-2-0",
+            phone_number: "070-3288-2552",
+            fax_number: "070-2623-8399",
+            email: "sample_maker0@example.com",
+            home_page: "https://example.com/sample_maker0",
+            manufacturer_rep: "宮本 悠斗"
           }
         }
 
         axios.patch.mockResolvedValue(mockResponse)
+
+        axios.get.mockResolvedValue({
+          data: {
+            id: 1,
+            name: "有限会社中野銀行",
+            postal_code: "962-0713",
+            address: "東京都渋谷区神南1-2-0",
+            phone_number: "070-3288-2552",
+            fax_number: "070-2623-8399",
+            email: "sample_maker0@example.com",
+            home_page: "https://example.com/sample_maker0",
+            manufacturer_rep: "宮本 悠斗"
+          }
+        })
 
         wrapper = mount(MakersEditView, {
           global: {
@@ -195,8 +216,18 @@ describe('MakersEditView', () => {
           }
         })
 
-        await wrapper.find('form').trigger('submit.prevent')
         await flushPromises()
+
+        expect(wrapper.find('#maker_name').element.value).toBe('有限会社中野銀行')
+        expect(wrapper.find('#maker_postal_code').element.value).toBe('962-0713')
+        expect(wrapper.find('#maker_address').element.value).toBe('東京都渋谷区神南1-2-0')
+        expect(wrapper.find('#maker_phone_number').element.value).toBe('070-3288-2552')
+        expect(wrapper.find('#maker_fax_number').element.value).toBe('070-2623-8399')
+        expect(wrapper.find('#maker_email').element.value).toBe('sample_maker0@example.com')
+        expect(wrapper.find('#maker_home_page').element.value).toBe('https://example.com/sample_maker0')
+        expect(wrapper.find('#maker_manufacturer_rep').element.value).toBe('宮本 悠斗')
+
+        await wrapper.find('form').trigger('submit.prevent')
 
         expect(axios.patch).toHaveBeenCalled()
         expect(pushMock).toHaveBeenCalledWith('/makers/1')
@@ -215,8 +246,8 @@ describe('MakersEditView', () => {
           }
         })
 
-        await wrapper.find('form').trigger('submit.prevent')
         await flushPromises()
+        await wrapper.find('form').trigger('submit.prevent')
 
         expect(wrapper.text()).toContain('入力に不備があります。')
       })

--- a/frontend/test/component/makers/MakersEditView.test.js
+++ b/frontend/test/component/makers/MakersEditView.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MakersEditView from '@/components/makers/MakersEditView.vue'
+
+describe('MakersEditView', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(MakersEditView)
+  })
+
+  describe('初期レンダリング', () => {
+    it('見出しが表示されること', () => {
+      expect(wrapper.find('h3').text()).toBe('メーカー情報の編集')
+    })
+
+    it('フォームが表示されること', () => {
+      expect(wrapper.find('form').exists()).toBe(true)
+    })
+
+    it('すべてのラベルが表示されること', () => {
+      expect(wrapper.find('label[for="maker_name"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_name"]').text()).toBe('メーカー名')
+
+      expect(wrapper.find('label[for="maker_postal_code"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_postal_code"]').text()).toBe('郵便番号')
+
+      expect(wrapper.find('label[for="maker_address"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_address"]').text()).toBe('住所')
+
+      expect(wrapper.find('label[for="maker_phone_number"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_phone_number"]').text()).toBe('電話番号')
+
+      expect(wrapper.find('label[for="maker_fax_number"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_fax_number"]').text()).toBe('FAX番号')
+
+      expect(wrapper.find('label[for="maker_email"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_email"]').text()).toBe('Email')
+
+      expect(wrapper.find('label[for="maker_home_page"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_home_page"]').text()).toBe('ホームページ')
+
+      expect(wrapper.find('label[for="maker_manufacturer_rep"]').exists()).toBe(true)
+      expect(wrapper.find('label[for="maker_manufacturer_rep"]').text()).toBe('担当者')
+    })
+
+    it('すべてのフォームフィールドが表示されること', () => {
+      expect(wrapper.find('#maker_name').exists()).toBe(true)
+      expect(wrapper.find('#maker_postal_code').exists()).toBe(true)
+      expect(wrapper.find('#maker_address').exists()).toBe(true)
+      expect(wrapper.find('#maker_phone_number').exists()).toBe(true)
+      expect(wrapper.find('#maker_fax_number').exists()).toBe(true)
+      expect(wrapper.find('#maker_email').exists()).toBe(true)
+      expect(wrapper.find('#maker_home_page').exists()).toBe(true)
+      expect(wrapper.find('#maker_manufacturer_rep').exists()).toBe(true)
+    })
+
+    it('ボタンが表示されること', () => {
+      expect(wrapper.find('button').exists()).toBe(true)
+      expect(wrapper.find('button').text()).toBe('更新')
+    })
+
+    it('外部リンクが表示されること', () => {
+      expect(wrapper.find('a').exists()).toBe(true)
+      expect(wrapper.find('a').text()).toBe('メーカーリストへ')
+    })
+  })
+})

--- a/frontend/test/component/makers/MakersEditView.test.js
+++ b/frontend/test/component/makers/MakersEditView.test.js
@@ -6,6 +6,7 @@ import axios from 'axios'
 vi.mock('axios')
 
 const pushMock = vi.fn()
+const replaceMock = vi.fn()
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual('vue-router')
@@ -19,7 +20,8 @@ vi.mock('vue-router', async () => {
     },
     useRouter: () => {
       return {
-        push: pushMock
+        push: pushMock,
+        replace: replaceMock
       }
     }
   }
@@ -152,11 +154,27 @@ describe('MakersEditView', () => {
       })
     })
 
-    // describe('メーカー情報の取得に失敗した場合', () => {
-    //   it('エラーメッセージが表示されること', () => {
-      
-    //   })
-    // })
+    describe('メーカー情報の取得に失敗した場合', () => {
+      it('404ページに遷移すること', async () => {
+        axios.get.mockRejectedValue({
+          response: {
+            status: 404
+          }
+        })
+
+        wrapper = mount(MakersEditView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
+
+        await flushPromises()
+        
+        expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
+      })
+    })
 
     describe('有効な情報を入力して送信すると', () => {
       it('更新が成功すること', async () => {

--- a/frontend/test/component/makers/MakersEditView.test.js
+++ b/frontend/test/component/makers/MakersEditView.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { flushPromises, mount } from '@vue/test-utils'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import MakersEditView from '@/components/makers/MakersEditView.vue'
 import axios from 'axios'
 
@@ -29,8 +29,28 @@ describe('MakersEditView', () => {
   let wrapper
 
   describe('初期レンダリング', () => {
+    axios.get.mockResolvedValue({
+      data: {
+        id: 1,
+        name: "有限会社中野銀行",
+        postal_code: "962-0713",
+        address: "東京都渋谷区神南1-2-0",
+        phone_number: "070-3288-2552",
+        fax_number: "070-2623-8399",
+        email: "sample_maker0@example.com",
+        home_page: "https://example.com/sample_maker0",
+        manufacturer_rep: "宮本 悠斗"
+      }
+    })
+    
     beforeEach(() => {
-      wrapper = mount(MakersEditView)
+      wrapper = mount(MakersEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
     })
 
     it('見出しが表示されること', () => {
@@ -84,8 +104,11 @@ describe('MakersEditView', () => {
     })
 
     it('外部リンクが表示されること', () => {
-      expect(wrapper.find('a').exists()).toBe(true)
-      expect(wrapper.find('a').text()).toBe('メーカーリストへ')
+      expect(wrapper.findComponent('#maker_information').text()).toBe('メーカー情報へ')
+      expect(wrapper.findComponent('#maker_information').props().to).toBe('/makers/1')
+
+      expect(wrapper.findComponent('#maker_list').text()).toBe('メーカーリストへ')
+      expect(wrapper.findComponent('#maker_list').props().to).toBe('/makers')
     })
   })
 
@@ -108,7 +131,14 @@ describe('MakersEditView', () => {
 
         axios.get.mockResolvedValue(mockResponse)
 
-        wrapper = mount(MakersEditView)
+        wrapper = mount(MakersEditView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
+
         await flushPromises()
 
         expect(wrapper.find('#maker_name').element.value).toBe('有限会社中野銀行')
@@ -139,7 +169,13 @@ describe('MakersEditView', () => {
 
         axios.patch.mockResolvedValue(mockResponse)
 
-        wrapper = mount(MakersEditView)
+        wrapper = mount(MakersEditView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
 
         await wrapper.find('form').trigger('submit.prevent')
         await flushPromises()
@@ -153,7 +189,13 @@ describe('MakersEditView', () => {
       it('更新が失敗すること', async () => {
         axios.patch.mockRejectedValue(new Error('Validation error'))
 
-        wrapper = mount(MakersEditView)
+        wrapper = mount(MakersEditView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
 
         await wrapper.find('form').trigger('submit.prevent')
         await flushPromises()

--- a/frontend/test/component/makers/MakersShowView.test.js
+++ b/frontend/test/component/makers/MakersShowView.test.js
@@ -19,6 +19,7 @@ describe('MakersShowView', () => {
   beforeEach(() => {
     axios.get.mockResolvedValue({
       data: { 
+        id: '1',
         name: '有限会社中野銀行',
         postal_code: '962-0713',
         address: '東京都渋谷区神南1-2-0',
@@ -66,7 +67,7 @@ describe('MakersShowView', () => {
     const listLink = links.find(link => link.attributes('id') === 'maker-list')
 
     expect(editLink.exists()).toBe(true)
-    expect(editLink.props().to).toBe('#')
+    expect(editLink.props().to).toBe('/makers/1/edit')
     
     expect(destroyLink.exists()).toBe(true)
     expect(destroyLink.props().to).toBe('#')

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import App from '@/App.vue'
 import router from '@/router'
 
@@ -19,7 +19,7 @@ describe('Makers routing', () => {
   })
 
   it('「メーカー情報」ページに遷移できること', async () => {
-    router.push('makers/1')
+    router.push('/makers/1')
 
     await router.isReady()
 
@@ -33,7 +33,7 @@ describe('Makers routing', () => {
   })
 
   it('「メーカー情報の新規登録」ページに遷移すること', async () => {
-    router.push('makers/new')
+    router.push('/makers/new')
 
     await router.isReady()
 
@@ -44,5 +44,21 @@ describe('Makers routing', () => {
     })
 
     expect(wrapper.html()).toContain('メーカー情報の登録')
+  })
+
+  it('「メーカー情報の編集」ページに遷移すること', async () => {
+    router.push('/makers/1/edit')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router]
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('メーカー情報の編集')
   })
 })


### PR DESCRIPTION
## 概要
Rails ビューの makers/edit を Vue.js でリファインする。
コンポーネント名：MakersEditView.vue
テスト名：MakersEditView.test.js

## 実装
- [x] コンポーネント
- [x] ルーティング
- [x] リクエスト・レスポンス
  - [x] メーカー情報の取得
  - [x] メーカー情報の更新
  - [x] エラーメッセージ
  - [x] マウント
- [x] 外部リンク
- [x] 改善事項

## 改善事項
- メイン
  - [x] 404 ページの追加
		
- テスト
  - [x] describe の「初期レンダリング」を「DOMの構造」に変更
  - [x] it の「〜表示されること」から「〜が存在すること」に変更
  - [x] 「Get maker data failed」の解消
  - [x] メーカー情報の取得に失敗した場合のテスト作成と 404 ページ追加
		
- UI/UX
  - 404 ページ
    - [x] ボタンのスタイル変更
    - [x] ボタンの遷移先変更