### PR TITLE
メーカーの削除機能

### DIFF
--- a/frontend/src/components/makers/MakersShowView.vue
+++ b/frontend/src/components/makers/MakersShowView.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { ref, onMounted } from 'vue'
 import axios from 'axios'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 const route = useRoute()
+const router = useRouter()
 const maker = ref({
   id: '',
   name: '',
@@ -23,6 +24,18 @@ const fetchMakerData = async (id) => {
     maker.value = response.data
   } catch (error) {
     console.error('Get maker information failed.')
+  }
+}
+
+const handleDelete = async () => {
+  const confirmDelete = window.confirm('本当に削除しますか？')
+  if (!confirmDelete) return
+
+  try {
+    await axios.delete(`${API_BASE_URL}/makers/${route.params.id}`)
+    router.push('/makers')
+  } catch (error) {
+    console.error('削除処理に失敗しました', error)
   }
 }
 
@@ -72,15 +85,20 @@ onMounted(() => {
       </div>
 
       <div class="d-flex justify-content-evenly">
-        <RouterLink v-if="maker.id" v-bind:to="`/makers/${maker.id}/edit`" id="maker-edit">メーカー情報の編集へ</RouterLink>
-        <RouterLink to="#" id="maker-destroy">メーカー情報の削除</RouterLink>
-        <RouterLink to="/makers" id="maker-list">メーカーリストへ</RouterLink>
+        <RouterLink v-if="maker.id" v-bind:to="`/makers/${maker.id}/edit`" id="maker_edit">メーカー情報の編集へ</RouterLink>
+        <p v-on:click="handleDelete" class="text-primary text-decoration-underline" id="maker_destroy">
+          メーカー情報の削除
+        </p>
+        <RouterLink to="/makers" id="maker_list">メーカーリストへ</RouterLink>
       </div>
     </div>
   </div>
 </template>
 
 <style>
+p {
+  cursor: pointer;
+}
 .custom-width {
   width: 45%;
 }

--- a/frontend/test/component/makers/MakersShowView.test.js
+++ b/frontend/test/component/makers/MakersShowView.test.js
@@ -5,7 +5,7 @@ import axios from 'axios'
 
 vi.mock('axios')
 
-vi.mock('vue-router', () => {
+vi.mock('vue-router', async () => {
   return {
     useRoute: () => {
       return {
@@ -77,19 +77,27 @@ describe('MakersShowView', () => {
     expect(wrapper.findComponent('#maker_list').props().to).toBe('/makers')
   })
 
-  it('メーカー情報の削除の選択でOKを押した場合、trueが返りhandleDeleteのイベントが発火すること', async () => {
-    const spy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-
-    await wrapper.find('p').trigger('click')
-
-    expect(spy.mock.results[0].value).toBe(true)
+  describe('メーカー情報の削除選択でOKを押した場合', () => {
+    it('axios.deleteが実行されること', async () => {
+      const spy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+      axios.delete = vi.fn()
+  
+      await wrapper.find('p').trigger('click')
+  
+      expect(spy.mock.results[0].value).toBe(true)
+      expect(axios.delete).toHaveBeenCalled()
+    })    
   })
 
-  it('メーカー情報の削除の選択でキャンセルを押した場合、falseが返りhandleDeleteのイベントが発火すること', async () => {
-    const spy = vi.spyOn(window, 'confirm').mockReturnValue(false)
-
-    await wrapper.find('p').trigger('click')
-
-    expect(spy.mock.results[0].value).toBe(false)
+  describe('メーカー情報の削除選択でキャンセルを押した場合', () => {
+    it('axion.deleteが実行されないこと', async () => {
+      const spy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+      axios.delete = vi.fn()
+  
+      await wrapper.find('p').trigger('click')
+  
+      expect(spy.mock.results[0].value).toBe(false)
+      expect(axios.delete).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/test/component/makers/MakersShowView.test.js
+++ b/frontend/test/component/makers/MakersShowView.test.js
@@ -5,13 +5,20 @@ import axios from 'axios'
 
 vi.mock('axios')
 
-vi.mock('vue-router', () => ({
-  useRoute: () => ({
-    params: {
-      id: '1'
+vi.mock('vue-router', () => {
+  return {
+    useRoute: () => {
+      return {
+        params: { id: '1' }
+      }
+    },
+    useRouter: () => {
+      return {
+        push: vi.fn()
+      }
     }
-  })
-}))
+  }
+})
 
 describe('MakersShowView', () => {
   let wrapper
@@ -55,24 +62,34 @@ describe('MakersShowView', () => {
   })
 
   it('外部リンクが表示されること', () => {
-    expect(wrapper.findComponent('a[id="maker-edit"]').text()).toBe('メーカー情報の編集へ')
-    expect(wrapper.findComponent('a[id="maker-destroy"]').text()).toBe('メーカー情報の削除')
-    expect(wrapper.findComponent('a[id="maker-list"]').text()).toBe('メーカーリストへ')
+    expect(wrapper.find('#maker_edit').exists()).toBe(true)
+    expect(wrapper.find('#maker_edit').text()).toBe('メーカー情報の編集へ')
+    
+    expect(wrapper.find('#maker_destroy').exists()).toBe(true)
+    expect(wrapper.find('#maker_destroy').text()).toBe('メーカー情報の削除')
+    
+    expect(wrapper.find('#maker_list').exists()).toBe(true)
+    expect(wrapper.find('#maker_list').text()).toBe('メーカーリストへ')
   })
 
   it('外部リンクのto属性が適切であること', () => {
-    const links = wrapper.findAllComponents(RouterLinkStub)
-    const editLink = links.find(link => link.attributes('id') === 'maker-edit')
-    const destroyLink = links.find(link => link.attributes('id') === 'maker-destroy')
-    const listLink = links.find(link => link.attributes('id') === 'maker-list')
+    expect(wrapper.findComponent('#maker_edit').props().to).toBe('/makers/1/edit')
+    expect(wrapper.findComponent('#maker_list').props().to).toBe('/makers')
+  })
 
-    expect(editLink.exists()).toBe(true)
-    expect(editLink.props().to).toBe('/makers/1/edit')
-    
-    expect(destroyLink.exists()).toBe(true)
-    expect(destroyLink.props().to).toBe('#')
+  it('メーカー情報の削除の選択でOKを押した場合、trueが返りhandleDeleteのイベントが発火すること', async () => {
+    const spy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
-    expect(listLink.exists()).toBe(true)
-    expect(listLink.props().to).toBe('/makers')
+    await wrapper.find('p').trigger('click')
+
+    expect(spy.mock.results[0].value).toBe(true)
+  })
+
+  it('メーカー情報の削除の選択でキャンセルを押した場合、falseが返りhandleDeleteのイベントが発火すること', async () => {
+    const spy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    await wrapper.find('p').trigger('click')
+
+    expect(spy.mock.results[0].value).toBe(false)
   })
 })


### PR DESCRIPTION
## 概要
Rails ビューの categories/show を Vue.js でリファインする。
今回は削除処理を部分的に追加する。
コンポーネント名：CategoriesShowView.vue
テスト名：CategoriesShowView.test.js

## 実装
- [x] コンポーネント
- [x] リクエスト・レスポンス
  - [x] メーカー情報の削除
- [x] 改善事項

## 改善事項
- テスト
  - [x] confirm() の検証テストに describe を追加して構造化