### PR TITLE
サンプル一覧の表示機能

### DIFF
--- a/backend/app/controllers/samples_controller.rb
+++ b/backend/app/controllers/samples_controller.rb
@@ -1,6 +1,6 @@
 class SamplesController < ApplicationController
   def index
-    samples = Sample.paginate(page: params[:page], per_page: 8)
+    samples = Sample.paginate(page: params[:page], per_page: 7)
 
     render json: {
       samples: samples,

--- a/backend/app/controllers/samples_controller.rb
+++ b/backend/app/controllers/samples_controller.rb
@@ -1,8 +1,12 @@
 class SamplesController < ApplicationController
   def index
-    @samples = Sample.all
+    samples = Sample.paginate(page: params[:page], per_page: 8)
 
-    render json: @samples
+    render json: {
+      samples: samples,
+      current_page: samples.current_page,
+      total_pages: samples.total_pages
+    }
   end
 
   def show

--- a/backend/spec/requests/samples_spec.rb
+++ b/backend/spec/requests/samples_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Samples API", type: :request do
       get "/samples"
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json.include?(:samples)).to be(true)
-      expect(json[:samples].count).to eq(8)
+      expect(json[:samples].count).to eq(7)
     end
 
     it 'レスポンスにcurrent_pageが含まれていること' do

--- a/backend/spec/requests/samples_spec.rb
+++ b/backend/spec/requests/samples_spec.rb
@@ -11,10 +11,25 @@ RSpec.describe "Samples API", type: :request do
       expect(response).to have_http_status(:success)
     end
 
-    it '表面処理リストが10件返ること' do
+    it 'レスポンスにsamplesが含まれていること' do
       get "/samples"
-      json = JSON.parse(response.body)
-      expect(json.count).to eq(10)
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json.include?(:samples)).to be(true)
+      expect(json[:samples].count).to eq(8)
+    end
+
+    it 'レスポンスにcurrent_pageが含まれていること' do
+      get "/samples"
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json.include?(:current_page)).to be(true)
+      expect(json[:current_page]).to eq(1)
+    end
+
+    it 'レスポンスにtotal_pagesが含まれていること' do
+      get "/samples"
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json.include?(:total_pages)).to be(true)  
+      expect(json[:total_pages]).to eq(2)  
     end
   end
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -44,5 +44,13 @@ onMounted(() => {
     </nav>
   </header>
 
-  <RouterView v-on:login-success="setUser" v-on:logout="logout"/>
+  <RouterView v-slot="{ Component }">
+    <component
+      :is="Component"
+      v-bind="{
+        ...(Component?.emits?.includes?.('login-success') && { onLoginSuccess: setUser }),
+        ...(Component?.emits?.includes?.('logout') && { onLogout: logout })
+      }"
+    />
+  </RouterView>
 </template>

--- a/frontend/src/components/HomeView.vue
+++ b/frontend/src/components/HomeView.vue
@@ -64,7 +64,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">表面処理の管理</h5>
             <p class="card-text">表面処理に関する情報を一括管理します。</p>
-            <RouterLink to="#" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/samples" class="card-link">管理ページへ</RouterLink>
           </div>
         </div>
       </div>

--- a/frontend/src/components/samples/SamplesIndexView.vue
+++ b/frontend/src/components/samples/SamplesIndexView.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="container text-center w-50">
+    <h3 class="mt-5 mb-5">表面処理リスト</h3>
+
+    <div class="list-group list-group-flush mb-2">
+      <div class="list-group-item list-group-item-action">
+        <div class="d-flex w-100 justify-content-between">
+          <h6 id="label_name_and_category">処理名 / カテゴリー</h6>
+          <h6 id="label_maker_name">メーカー名</h6>
+        </div>
+      </div>
+
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>無電解ニッケルめっき</h6>
+          <h6>合名会社西村ガス</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+    
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>白金めっき</h6>
+          <h6>合同会社山口運輸</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+    
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>金めっき</h6>
+          <h6>藤本情報株式会社</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+    
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>銀めっき</h6>
+          <h6>岩崎通信株式会社</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>銅めっき</h6>
+          <h6>合同会社高木印刷</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>亜鉛めっき</h6>
+          <h6>株式会社後藤運輸</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>錫めっき</h6>
+          <h6>上田鉱業合同会社</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+      
+      <a class="list-group-item list-group-item-action" href="/samples/#">
+        <div class="d-flex w-100 justify-content-between">
+          <h6>ニッケルめっき</h6>
+          <h6>宮本食品合同会社</h6>
+        </div>
+        <h6 class="text-start">めっき</h6>
+      </a>
+    </div>
+
+    <ul class="pagination justify-content-center mb-5">
+      <li class="page-item disabled">
+        <a class="page-link" id="previous_page">前のページ</a>
+      </li>
+      <li class="page-item active">
+        <a class="page-link" href="/samples?page=#">1</a>
+      </li>
+      <li class="page-item ">
+        <a class="page-link" href="/samples?page=#">2</a>
+      </li>
+      <li class="page-item ">
+        <a class="page-link" href="/samples?page=#">3</a>
+      </li>
+      <li class="page-item ">
+        <a class="page-link" href="/samples?page=#">4</a>
+      </li>
+      <li class="page-item">
+        <a class="page-link" id="next_page" href="/samples?page=#">次のページ</a>
+      </li>
+    </ul>
+
+    <div class="d-flex justify-content-evenly">
+      <a href="/samples/new">表面処理情報の登録</a>
+      <a href="/home">メインメニューへ</a>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/samples/SamplesIndexView.vue
+++ b/frontend/src/components/samples/SamplesIndexView.vue
@@ -1,3 +1,25 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const samples = ref('')
+
+const fetchSampleList = async () => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/samples`)
+    samples.value = response.data
+  } catch (error) {
+    console.error('Get sample list failed')
+  }
+}
+
+onMounted(() => {
+  fetchSampleList()
+})
+</script>
+
+
 <template>
   <div class="container text-center w-50">
     <h3 class="mt-5 mb-5">表面処理リスト</h3>
@@ -10,68 +32,12 @@
         </div>
       </div>
 
-      <a class="list-group-item list-group-item-action" href="/samples/#">
+      <a v-for="sample in samples" v-bind:key="sample.id" class="list-group-item list-group-item-action" href="/samples/#">
         <div class="d-flex w-100 justify-content-between">
-          <h6>無電解ニッケルめっき</h6>
-          <h6>合名会社西村ガス</h6>
+          <h6>{{ sample.name }}</h6>
+          <h6>{{ sample.maker }}</h6>
         </div>
-        <h6 class="text-start">めっき</h6>
-      </a>
-    
-      <a class="list-group-item list-group-item-action" href="/samples/#">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>白金めっき</h6>
-          <h6>合同会社山口運輸</h6>
-        </div>
-        <h6 class="text-start">めっき</h6>
-      </a>
-    
-      <a class="list-group-item list-group-item-action" href="/samples/#">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>金めっき</h6>
-          <h6>藤本情報株式会社</h6>
-        </div>
-        <h6 class="text-start">めっき</h6>
-      </a>
-    
-      <a class="list-group-item list-group-item-action" href="/samples/#">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>銀めっき</h6>
-          <h6>岩崎通信株式会社</h6>
-        </div>
-        <h6 class="text-start">めっき</h6>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="/samples/#">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>銅めっき</h6>
-          <h6>合同会社高木印刷</h6>
-        </div>
-        <h6 class="text-start">めっき</h6>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="/samples/#">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>亜鉛めっき</h6>
-          <h6>株式会社後藤運輸</h6>
-        </div>
-        <h6 class="text-start">めっき</h6>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="/samples/#">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>錫めっき</h6>
-          <h6>上田鉱業合同会社</h6>
-        </div>
-        <h6 class="text-start">めっき</h6>
-      </a>
-      
-      <a class="list-group-item list-group-item-action" href="/samples/#">
-        <div class="d-flex w-100 justify-content-between">
-          <h6>ニッケルめっき</h6>
-          <h6>宮本食品合同会社</h6>
-        </div>
-        <h6 class="text-start">めっき</h6>
+        <h6 class="text-start">{{ sample.category }}</h6>
       </a>
     </div>
 

--- a/frontend/src/components/samples/SamplesIndexView.vue
+++ b/frontend/src/components/samples/SamplesIndexView.vue
@@ -37,7 +37,7 @@ onMounted(() => {
 
 
 <template>
-  <div class="container text-center w-50">
+  <div class="container text-center w-25">
     <h3 class="mt-5 mb-5">表面処理リスト</h3>
 
     <div class="list-group list-group-flush mb-2">
@@ -53,7 +53,10 @@ onMounted(() => {
           <h6>{{ sample.name }}</h6>
           <h6>{{ sample.maker }}</h6>
         </div>
-        <h6 class="text-start">{{ sample.category }}</h6>
+        <div class="d-flex w-100 justify-content-between">
+          <h6>{{ sample.category }}</h6>
+          <h6>{{ sample.color }}</h6>
+        </div>
       </a>
     </div>
 

--- a/frontend/src/components/samples/SamplesIndexView.vue
+++ b/frontend/src/components/samples/SamplesIndexView.vue
@@ -74,8 +74,8 @@ onMounted(() => {
     </ul>
 
     <div class="d-flex justify-content-evenly">
-      <a href="/samples/new">表面処理情報の登録</a>
-      <a href="/home">メインメニューへ</a>
+      <RouterLink to="#" id="link_samples_new">表面処理情報の登録</RouterLink>
+      <RouterLink to="/home" id="link_home">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -16,6 +16,7 @@ import MakersShowView from './components/makers/MakersShowView.vue'
 import MakersNewView from './components/makers/MakersNewView.vue'
 import MakersEditView from './components/makers/MakersEditView.vue'
 import NotFound from './components/NotFound.vue'
+import SamplesIndexView from './components/samples/SamplesIndexView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -35,7 +36,8 @@ const routes = [
   { path: '/makers/:id', component: MakersShowView },
   { path: '/makers/new', component: MakersNewView },
   { path: '/makers/:id/edit', component: MakersEditView },
-  { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound}
+  { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound},
+  { path: '/samples', component: SamplesIndexView},
 ]
 
 const router = createRouter({

--- a/frontend/test/component/HomeView.test.js
+++ b/frontend/test/component/HomeView.test.js
@@ -66,7 +66,7 @@ describe('HomeView', () => {
       expect(links[1].attributes('href')).toBe('#')
       expect(links[2].attributes('href')).toBe('#')
       expect(links[3].attributes('href')).toBe('#')
-      expect(links[4].attributes('href')).toBe('#')
+      expect(links[4].attributes('href')).toBe('/samples')
       expect(links[5].attributes('href')).toBe('/categories')
       expect(links[6].attributes('href')).toBe('/makers')
       expect(links[7].attributes('href')).toBe('/users')

--- a/frontend/test/component/samples/SamplesIndexView.test.js
+++ b/frontend/test/component/samples/SamplesIndexView.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SamplesIndexView from '@/components/samples/SamplesIndexView.vue'
+
+describe('SamplesIndexView', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(SamplesIndexView)  
+  })
+
+  describe('DOMの構造', () => {
+    it('見出しが存在すること', () => {
+      expect(wrapper.find('h3').text()).toBe('表面処理リスト')
+    })
+
+    it('項目のラベルが存在すること', () => {
+      expect(wrapper.find('#label_name_and_category').text()).toBe('処理名 / カテゴリー')
+      expect(wrapper.find('#label_maker_name').text()).toBe('メーカー名')
+    })
+    
+    it('リストが8件表示されること', () => {
+      const links = wrapper.findAll('a[href="/samples/#"]')
+      expect(links.length).toBe(8)
+    })
+
+    it('ページネーションが存在すること', () => {
+      expect(wrapper.find('.pagination').exists()).toBe(true)
+      expect(wrapper.find('#previous_page').text()).toBe('前のページ')
+      expect(wrapper.find('#next_page').text()).toBe('次のページ')
+    })
+
+    it('外部リンクが存在すること', () => {
+      expect(wrapper.find('a[href="/samples/new"]').text()).toBe('表面処理情報の登録')
+      expect(wrapper.find('a[href="/home"]').text()).toBe('メインメニューへ')
+    })
+  })
+})

--- a/frontend/test/component/samples/SamplesIndexView.test.js
+++ b/frontend/test/component/samples/SamplesIndexView.test.js
@@ -154,7 +154,7 @@ describe('SamplesIndexView', () => {
   })
 
   describe('API通信', () => {
-    it('表面処理リストが8件表示されること', () => {
+    it('表面処理リストが7件表示されること', () => {
       expect(wrapper.html()).toContain('無電解ニッケルめっき')
       expect(wrapper.html()).toContain('白金めっき')
       expect(wrapper.html()).toContain('金めっき')

--- a/frontend/test/component/samples/SamplesIndexView.test.js
+++ b/frontend/test/component/samples/SamplesIndexView.test.js
@@ -1,12 +1,143 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import SamplesIndexView from '@/components/samples/SamplesIndexView.vue'
+import axios from 'axios'
+
+vi.mock('axios')
+
+vi.mock('vue-router', () => {
+  return {
+    useRoute: () => {
+      return {
+        query: { page: '1' }
+      }
+    }
+  }
+})
 
 describe('SamplesIndexView', () => {
   let wrapper
 
   beforeEach(() => {
-    wrapper = mount(SamplesIndexView)  
+    axios.get.mockResolvedValue({
+      data: {
+        samples: [
+          {
+            "id": 1,
+            "name": "無電解ニッケルめっき",
+            "category": "めっき",
+            "color": "イエローブラウンシルバー",
+            "maker": "小島印刷合同会社",
+            "created_at": "2025-02-23T22:15:29.815Z",
+            "updated_at": "2025-02-23T22:15:29.815Z",
+            "picture": "#<File:0x0000ffff859a8be0>",
+            "hardness": "析出状態の皮膜硬度でHV550～HV700、熱処理後の皮膜硬度はHV950程度",
+            "film_thickness": "通常は3～5μm、厚めの場合は20～50μmまで可能",
+            "feature": "耐食性・耐摩耗性・耐薬品性・耐熱性"
+          },
+          {
+            "id": 2,
+            "name": "白金めっき",
+            "category": "めっき",
+            "color": "シルバー",
+            "maker": "小山印刷合資会社",
+            "created_at": "2025-02-23T22:15:29.817Z",
+            "updated_at": "2025-02-23T22:15:29.817Z",
+            "picture": "#<File:0x0000ffff85969828>",
+            "hardness": "Hv300～Hv400程度",
+            "film_thickness": "水素水生成器用の白金電極では0.5～2.0μm、装飾品では0.1～0.5μm程度",
+            "feature": "耐蝕性・導電性・耐摩耗性・耐熱性"
+          },
+          {
+            "id": 3,
+            "name": "金めっき",
+            "category": "めっき",
+            "color": "ゴールド",
+            "maker": "合名会社木下銀行",
+            "created_at": "2025-02-23T22:15:29.818Z",
+            "updated_at": "2025-02-23T22:15:29.818Z",
+            "picture": "#<File:0x0000ffff85a1ab00>",
+            "hardness": "HV60～80程度",
+            "film_thickness": "下地ニッケルめっきは3～5μm、金めっきは0.1～1.0μm",
+            "feature": "耐食性・耐酸化性・電気抵抗性"
+          },
+          {
+            "id": 4,
+            "name": "銀めっき",
+            "category": "めっき",
+            "color": "シルバー",
+            "maker": "杉山食品有限会社",
+            "created_at": "2025-02-23T22:15:29.819Z",
+            "updated_at": "2025-02-23T22:15:29.819Z",
+            "picture": "#<File:0x0000ffff85aebde0>",
+            "hardness": "HV60～80程度",
+            "film_thickness": "0.1～3μm程度",
+            "feature": "耐摩耗性・潤滑性・耐食性・導電性"
+          },
+          {
+            "id": 5,
+            "name": "銅めっき",
+            "category": "めっき",
+            "color": "ブロンズ",
+            "maker": "金子保険合資会社",
+            "created_at": "2025-02-23T22:15:29.821Z",
+            "updated_at": "2025-02-23T22:15:29.821Z",
+            "picture": "#<File:0x0000ffff85b8cd30>",
+            "hardness": "無光沢でHv80～120、光沢でHv80～200程度",
+            "film_thickness": "0.2～2μm程度",
+            "feature": "抗菌性・密着性"
+          },
+          {
+            "id": 6,
+            "name": "亜鉛めっき",
+            "category": "めっき",
+            "color": "シルバー",
+            "maker": "中島水産合名会社",
+            "created_at": "2025-02-23T22:15:29.822Z",
+            "updated_at": "2025-02-23T22:15:29.822Z",
+            "picture": "#<File:0x0000ffff85c3da40>",
+            "hardness": "シアン浴でHv60～90、ジンケート浴でHv100～140、塩化浴でHv60～90",
+            "film_thickness": "5～20μm程度",
+            "feature": "耐食性・耐腐食性・密着性"
+          },
+          {
+            "id": 7,
+            "name": "錫めっき",
+            "category": "めっき",
+            "color": "ホワイトシルバー",
+            "maker": "合名会社今井情報",
+            "created_at": "2025-02-23T22:15:29.824Z",
+            "updated_at": "2025-02-23T22:15:29.824Z",
+            "picture": "#<File:0x0000ffff85cdea58>",
+            "hardness": "Hv9.5～10.5程度",
+            "film_thickness": "光沢スズめっきで3～10μm、無光沢スズめっきで5～20μm程度",
+            "feature": "耐食性・潤滑性・摺動性"
+          },
+          {
+            "id": 8,
+            "name": "ニッケルめっき",
+            "category": "めっき",
+            "color": "ライトシルバー",
+            "maker": "合資会社村田ガス",
+            "created_at": "2025-02-23T22:15:29.825Z",
+            "updated_at": "2025-02-23T22:15:29.825Z",
+            "picture": "#<File:0x0000ffff85d4fd20>",
+            "hardness": "Hv350 ～500程度",
+            "film_thickness": "3～30μm程度",
+            "feature": "耐食性・耐薬品性・耐熱性"
+          },
+        ],
+        curent_page: 1,
+        total_pages: 1
+      }
+    }),
+    wrapper = mount(SamplesIndexView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })  
   })
 
   describe('DOMの構造', () => {
@@ -19,21 +150,29 @@ describe('SamplesIndexView', () => {
       expect(wrapper.find('#label_maker_name').text()).toBe('メーカー名')
     })
     
-    // このテストはページネーションを設定した際に復活させること
-    // it('リストが8件表示されること', () => {
-    //   const links = wrapper.findAll('a[href="/samples/#"]')
-    //   expect(links.length).toBe(8)
-    // })
-
     it('ページネーションが存在すること', () => {
-      expect(wrapper.find('.pagination').exists()).toBe(true)
-      expect(wrapper.find('#previous_page').text()).toBe('前のページ')
-      expect(wrapper.find('#next_page').text()).toBe('次のページ')
+      expect(wrapper.find('#pagination').exists()).toBe(true)
+      expect(wrapper.find('#pagination_previous_page').text()).toBe('前ページ')
+      expect(wrapper.find('#pagination_next_page').text()).toBe('次ページ')
+
     })
 
     it('外部リンクが存在すること', () => {
       expect(wrapper.find('a[href="/samples/new"]').text()).toBe('表面処理情報の登録')
       expect(wrapper.find('a[href="/home"]').text()).toBe('メインメニューへ')
+    })
+  })
+
+  describe('API通信', () => {
+    it('表面処理リストが8件表示されること', () => {
+      expect(wrapper.html()).toContain('無電解ニッケルめっき')
+      expect(wrapper.html()).toContain('白金めっき')
+      expect(wrapper.html()).toContain('金めっき')
+      expect(wrapper.html()).toContain('銀めっき')
+      expect(wrapper.html()).toContain('銅めっき')
+      expect(wrapper.html()).toContain('亜鉛めっき')
+      expect(wrapper.html()).toContain('錫めっき')
+      expect(wrapper.html()).toContain('ニッケルめっき')
     })
   })
 })

--- a/frontend/test/component/samples/SamplesIndexView.test.js
+++ b/frontend/test/component/samples/SamplesIndexView.test.js
@@ -113,19 +113,6 @@ describe('SamplesIndexView', () => {
             "film_thickness": "光沢スズめっきで3～10μm、無光沢スズめっきで5～20μm程度",
             "feature": "耐食性・潤滑性・摺動性"
           },
-          {
-            "id": 8,
-            "name": "ニッケルめっき",
-            "category": "めっき",
-            "color": "ライトシルバー",
-            "maker": "合資会社村田ガス",
-            "created_at": "2025-02-23T22:15:29.825Z",
-            "updated_at": "2025-02-23T22:15:29.825Z",
-            "picture": "#<File:0x0000ffff85d4fd20>",
-            "hardness": "Hv350 ～500程度",
-            "film_thickness": "3～30μm程度",
-            "feature": "耐食性・耐薬品性・耐熱性"
-          },
         ],
         curent_page: 1,
         total_pages: 1
@@ -175,7 +162,6 @@ describe('SamplesIndexView', () => {
       expect(wrapper.html()).toContain('銅めっき')
       expect(wrapper.html()).toContain('亜鉛めっき')
       expect(wrapper.html()).toContain('錫めっき')
-      expect(wrapper.html()).toContain('ニッケルめっき')
     })
   })
 })

--- a/frontend/test/component/samples/SamplesIndexView.test.js
+++ b/frontend/test/component/samples/SamplesIndexView.test.js
@@ -19,10 +19,11 @@ describe('SamplesIndexView', () => {
       expect(wrapper.find('#label_maker_name').text()).toBe('メーカー名')
     })
     
-    it('リストが8件表示されること', () => {
-      const links = wrapper.findAll('a[href="/samples/#"]')
-      expect(links.length).toBe(8)
-    })
+    // このテストはページネーションを設定した際に復活させること
+    // it('リストが8件表示されること', () => {
+    //   const links = wrapper.findAll('a[href="/samples/#"]')
+    //   expect(links.length).toBe(8)
+    // })
 
     it('ページネーションが存在すること', () => {
       expect(wrapper.find('.pagination').exists()).toBe(true)

--- a/frontend/test/component/samples/SamplesIndexView.test.js
+++ b/frontend/test/component/samples/SamplesIndexView.test.js
@@ -158,8 +158,11 @@ describe('SamplesIndexView', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.find('a[href="/samples/new"]').text()).toBe('表面処理情報の登録')
-      expect(wrapper.find('a[href="/home"]').text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent('#link_samples_new').text()).toBe('表面処理情報の登録')
+      expect(wrapper.findComponent('#link_samples_new').props().to).toBe('#')
+
+      expect(wrapper.findComponent('#link_home').text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent('#link_home').props().to).toBe('/home')
     })
   })
 

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -62,3 +62,21 @@ describe('Makers routing', () => {
     expect(wrapper.html()).toContain('メーカー情報の編集')
   })
 })
+
+describe('Samples routing', () => {
+  it('「表面処理リスト」ページに遷移すること', async () => {
+    router.push('/samples')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router]
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('表面処理リスト')
+  })
+})


### PR DESCRIPTION
## 概要
Rails ビューの samples/index を Vue.js でリファインする。
コンポーネント名：SamplesIndexView.vue
テスト名：SamplesIndexView.test.js

## 実装
- [x] コンポーネント
- [x] ルーティング
- [x] リクエスト・レスポンス
  - [x] 一旦すべてのリストを表示
  - [x] ページネーションで分割
- [x] 外部リンク
- [x] 改善事項

## 改善事項
- メイン
  - [x] container サイズを w-25 に変更
  - [x] ページ当たりの表示件数を 7 から 8 に変更
  - [x] 項目「カラー」を追加

## 参考文献
- []()