### PR TITLE
サンプルの削除機能

### DIFF
--- a/backend/app/controllers/samples_controller.rb
+++ b/backend/app/controllers/samples_controller.rb
@@ -38,6 +38,8 @@ class SamplesController < ApplicationController
   def destroy
     @sample = Sample.find(params[:id])
     @sample.destroy
+    
+    head :no_content
   end
 
   private

--- a/backend/spec/requests/samples_spec.rb
+++ b/backend/spec/requests/samples_spec.rb
@@ -201,6 +201,11 @@ RSpec.describe "Samples API", type: :request do
       @sample.comments.create(commenter: 'sample user', department: 'department', body: 'sample comment.')
     end
 
+    it 'レスポンスのステータスがno_contentであること' do
+      delete "/samples/#{@sample.id}"      
+      expect(response).to have_http_status(:no_content)
+    end
+    
     it '表面処理の削除に成功すること' do
       expect { delete "/samples/#{@sample.id}" }.to change{ Sample.count }.from(1).to(0)
     end

--- a/frontend/src/components/samples/SamplesShowView.vue
+++ b/frontend/src/components/samples/SamplesShowView.vue
@@ -49,6 +49,18 @@ const formatDate = (isoString) => {
   return `${year}/${month}/${day}`
 }
 
+const handleDelete = async () => {
+  const confirmDelete = window.confirm('本当に削除しますか？')
+  if (!confirmDelete) return
+
+  try {
+    await axios.delete(`${API_BASE_URL}/samples/${route.params.id}`)
+    router.push('/samples')
+  } catch (error) {
+    console.error('削除処理に失敗しました')
+  }
+}
+
 onMounted(() => {
   fetchSampleData(route.params.id)
   fetchSampleCommentsData(route.params.id)
@@ -126,8 +138,19 @@ onMounted(() => {
 
     <div class="d-flex justify-content-evenly mt-5 mb-5">
       <RouterLink v-bind:to="`/samples/${sample.id}/edit`" id="link_sample_edit">表面処理情報の編集</RouterLink>
-      <RouterLink to="#" id="link_sample_destroy">表面処理情報の削除</RouterLink>
+      <p v-on:click="handleDelete" class="text-primary text-decoration-underline" id="link_sample_destroy">
+        表面処理情報の削除
+      </p>
       <RouterLink to="/home" id="link_home">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>
+
+<style>
+p {
+  cursor: pointer;
+}
+.custom-width {
+  width: 45%;
+}
+</style>

--- a/frontend/test/component/samples/SamplesShowView.test.js
+++ b/frontend/test/component/samples/SamplesShowView.test.js
@@ -6,6 +6,7 @@ import axios from 'axios'
 vi.mock('axios')
 
 const replaceMock = vi.fn()
+const pushMock = vi.fn()
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual('vue-router')
@@ -19,7 +20,8 @@ vi.mock('vue-router', async () => {
     },
     useRouter: () => {
       return {
-        replace: replaceMock
+        replace: replaceMock,
+        push: pushMock
       }
     }
   }
@@ -232,6 +234,53 @@ describe('SamplesShowView', () => {
         await flushPromises()
 
         expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
+      })
+    })
+
+    describe('表面処理の削除選択でOKを押した場合', () => {
+      it('axios.deleteが実行されること', async () => {
+        const spy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+        axios.delete = vi.fn()
+
+        const wrapper = mount(SamplesShowView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
+
+        await flushPromises()
+
+        await wrapper.find('#link_sample_destroy').trigger('click')
+        await flushPromises()
+
+        expect(spy.mock.results[0].value).toBe(true)
+        expect(axios.delete).toHaveBeenCalled()
+        expect(pushMock).toHaveBeenCalledWith('/samples')
+      })
+    })
+    
+    describe('表面処理の削除選択でキャンセルを押した場合', () => {
+      it('axios.deleteが実行されないこと', async () => {
+        const spy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+        axios.delete = vi.fn()
+  
+        const wrapper = mount(SamplesShowView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
+  
+        await flushPromises()
+  
+        await wrapper.find('#link_sample_destroy').trigger('click')
+        await flushPromises()
+  
+        expect(spy.mock.results[0].value).toBe(false)
+        expect(axios.delete).not.toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
## 概要
サンプルの削除機能を追加する。

## 実装
- backend
  - [x] destroy アクションの処理内容見直し
- frontend 
  - [x] SamplesShowView へ handleDelete イベント追加