### PR TITLE
カテゴリーで検索の実装

### DIFF
--- a/backend/app/controllers/searches_controller.rb
+++ b/backend/app/controllers/searches_controller.rb
@@ -8,4 +8,14 @@ class SearchesController < ApplicationController
       keyword: keyword
     }
   end
+
+  def category_search
+    samples = Sample.category_search(params[:keyword])
+    keyword = params[:keyword]
+
+    render json: {
+      samples: samples,
+      keyword: keyword
+    }
+  end
 end

--- a/backend/app/models/sample.rb
+++ b/backend/app/models/sample.rb
@@ -14,9 +14,9 @@ class Sample < ApplicationRecord
   validates :film_thickness, presence: { message: '（膜厚）が空白です。' }
   validates :feature,        presence: { message: '（特徴）が空白です。' }
 
-  scope :name_search,     -> (keyword)    { where('name LIKE ?',     "%#{keyword}%") }
-  scope :category_search, -> (selectword) { where('category LIKE ?', "%#{selectword}%") }
-  scope :maker_search,    -> (keyword)    { where('maker LIKE ?',    "%#{keyword}%") }
+  scope :name_search,     -> (keyword) { where('name LIKE ?',     "%#{keyword}%") }
+  scope :category_search, -> (keyword) { where('category LIKE ?', "%#{keyword}%") }
+  scope :maker_search,    -> (keyword) { where('maker LIKE ?',    "%#{keyword}%") }
 
   def image_url
     image.attached? ? url_for(image) : nil  

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
   delete '/logout',    to: 'sessions#destroy'
   get    '/logged_in', to: 'sessions#logged_in?'
 
-  get '/name_search', to: 'searches#name_search'
+  get '/name_search',     to: 'searches#name_search'
+  get '/category_search', to: 'searches#category_search'
 
   resources :categories
   resources :makers

--- a/backend/spec/requests/searches_spec.rb
+++ b/backend/spec/requests/searches_spec.rb
@@ -21,22 +21,22 @@ RSpec.describe "Searches", type: :request do
     end
   end
 
-  # describe '#category_search' do
-  #   it 'レスポンスが正常であること' do
-  #     get category_category_search_path
-  #     expect(response).to have_http_status(:success)
-  #   end
+  describe '#category_search' do
+    it 'レスポンスのステータスがsuccessであること' do
+      get '/category_search'
+      expect(response).to have_http_status(:success)
+    end
 
-  #   it 'タイトルが表示されること' do
-  #     get category_category_search_path
-  #     expect(response.body).to include('<title>カテゴリーでの検索結果</title>')
-  #   end
+    it 'レスポンスのjsonに:samplesと:keywordが含まれていること' do
+      get '/category_search', params: { keyword: 'めっき' }
+      json = JSON.parse(response.body, symbolize_names: true)
 
-  #   it '"無電解ニッケルめっき"が表示されること' do
-  #     get category_category_search_path, params: { search: 'めっき' }
-  #     expect(response.body).to include("無電解ニッケルめっき")
-  #   end
-  # end
+      expect(json.include?(:samples)).to be(true)
+      expect(json.include?(:keyword)).to be(true)
+      expect(json[:samples].count).to eq(5)
+      expect(json[:keyword]).to eq('めっき')
+    end
+  end
 
   # describe '#maker_search' do
   #   it 'レスポンスが正常であること' do

--- a/frontend/src/components/HomeView.vue
+++ b/frontend/src/components/HomeView.vue
@@ -31,7 +31,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">カテゴリーで検索</h5>
             <p class="card-text">カテゴリーを選択して表面処理を検索します。</p>
-            <RouterLink to="#" class="card-link">検索ページへ</RouterLink>
+            <RouterLink to="/static_pages/category" class="card-link">検索ページへ</RouterLink>
           </div>
         </div>
       </div>

--- a/frontend/src/components/search_results/SearchResultsView.vue
+++ b/frontend/src/components/search_results/SearchResultsView.vue
@@ -7,12 +7,14 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 const route = useRoute()
 const data = ref('')
 const samples = ref('')
+const searchMethod = ref('')
 
 const fetchSearchResults = async () => {
   const keyword = route.query.keyword
-
+  searchMethod.value = route.params.searchMethod
+  
   try {
-    const response = await axios.get(`${API_BASE_URL}/name_search`, {
+    const response = await axios.get(`${API_BASE_URL}/${searchMethod.value}_search`, {
       params: { keyword: keyword }
     })
     data.value = response.data
@@ -56,8 +58,8 @@ onMounted(() => {
     </div>
 
     <div class="d-flex justify-content-evenly mt-5 mb-5">
-      <RouterLink to="/static_pages/name" id="link_research">再検索</RouterLink>
-      <RouterLink to="/home" id="link_home">メインメニューへ</RouterLink>
+      <RouterLink v-bind:to="`/static_pages/${searchMethod}`" id="link_research" ref="linkResearch">再検索</RouterLink>
+      <RouterLink to="/home" id="link_home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/static_pages/StaticPagesCategoryView.vue
+++ b/frontend/src/components/static_pages/StaticPagesCategoryView.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="container text-center w-25">
+    <h3 class="mt-5 mb-5">カテゴリーで検索</h3>
+    <form>
+      <select name="keyword" class="form-select mb-3">
+        <option value="">カテゴリーを選択して下さい</option>
+        <option value="めっき">めっき</option>
+        <option value="陽極酸化">陽極酸化</option>
+        <option value="化成">化成</option>
+        <option value="コーティング">コーティング</option>
+        <option value="表面硬化">表面硬化</option>
+      </select>
+      <button type="submit" class="btn btn-secondary form-control mb-5">検索</button>
+    </form>
+    <div>
+      <RouterLink to="/home">メインメニューへ</RouterLink>
+    </div>
+  </div>
+</template>
+

--- a/frontend/src/components/static_pages/StaticPagesCategoryView.vue
+++ b/frontend/src/components/static_pages/StaticPagesCategoryView.vue
@@ -1,8 +1,24 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const keyword = ref('')
+const router = useRouter()
+
+const submitSearch = () => {
+  router.push({
+    name: 'SearchResults',
+    params: { searchMethod: 'category' },
+    query: { keyword: keyword.value }
+  })
+}
+</script>
+
 <template>
   <div class="container text-center w-25">
     <h3 class="mt-5 mb-5">カテゴリーで検索</h3>
-    <form>
-      <select name="keyword" class="form-select mb-3">
+    <form v-on:submit.prevent="submitSearch">
+      <select v-model="keyword" class="form-select mb-3">
         <option value="">カテゴリーを選択して下さい</option>
         <option value="めっき">めっき</option>
         <option value="陽極酸化">陽極酸化</option>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -21,6 +21,7 @@ import SamplesShowView from './components/samples/SamplesShowView.vue'
 import SamplesNewView from './components/samples/SamplesNewView.vue'
 import SamplesEditView from './components/samples/SamplesEditView.vue'
 import StaticPagesNameView from './components/static_pages/StaticPagesNameView.vue'
+import StaticPagesCategoryView from './components/static_pages/StaticPagesCategoryView.vue'
 import SearchResultsView from './components/search_results/SearchResultsView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
@@ -47,6 +48,7 @@ const routes = [
   { path: '/samples/new', component: SamplesNewView },
   { path: '/samples/:id/edit', component: SamplesEditView },
   { path: '/static_pages/name', component: StaticPagesNameView },
+  { path: '/static_pages/category', component: StaticPagesCategoryView }, 
   {
     path: '/static_pages/:searchMethod(name|category|maker)/search_results',
     component: SearchResultsView,

--- a/frontend/test/component/HomeView.test.js
+++ b/frontend/test/component/HomeView.test.js
@@ -63,7 +63,7 @@ describe('HomeView', () => {
       const links = wrapper.findAll('a')
 
       expect(links[0].attributes('href')).toBe('/static_pages/name')
-      expect(links[1].attributes('href')).toBe('#')
+      expect(links[1].attributes('href')).toBe('/static_pages/category')
       expect(links[2].attributes('href')).toBe('#')
       expect(links[3].attributes('href')).toBe('#')
       expect(links[4].attributes('href')).toBe('/samples')

--- a/frontend/test/component/static_pages/StaticPagesCategoryView.test.js
+++ b/frontend/test/component/static_pages/StaticPagesCategoryView.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import StaticPagesCategoryView from '@/components/static_pages/StaticPagesCategoryView.vue'
+// import { RouterLink } from 'vue-router'
+
+describe('StaticPagesCategory', () => {
+  describe('DOMの構造', () => {
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = mount(StaticPagesCategoryView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+    })
+
+    it('見出しが存在すること', () => {
+      expect(wrapper.find('h3').exists()).toBe(true)
+      expect(wrapper.find('h3').text()).toBe('カテゴリーで検索')
+    })
+
+    it('ドロップダウンリストが存在すること', () => {
+      expect(wrapper.find('select').exists()).toBe(true)
+
+      expect(wrapper.find('option[value="めっき"]').exists()).toBe(true)
+      expect(wrapper.find('option[value="めっき"]').text()).toBe('めっき')
+      
+      expect(wrapper.find('option[value="陽極酸化"]').exists()).toBe(true)
+      expect(wrapper.find('option[value="陽極酸化"]').text()).toBe('陽極酸化')
+      
+      expect(wrapper.find('option[value="化成"]').exists()).toBe(true)
+      expect(wrapper.find('option[value="化成"]').text()).toBe('化成')
+      
+      expect(wrapper.find('option[value="コーティング"]').exists()).toBe(true)
+      expect(wrapper.find('option[value="コーティング"]').text()).toBe('コーティング')
+      
+      expect(wrapper.find('option[value="表面硬化"]').exists()).toBe(true)
+      expect(wrapper.find('option[value="表面硬化"]').text()).toBe('表面硬化')
+    })
+
+    it('ボタンが存在すること', () => {
+      expect(wrapper.find('button').exists()).toBe(true)
+      expect(wrapper.find('button').text()).toBe('検索')
+    })
+
+    it('外部リンクが存在すること', () => {
+      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
+      expect(wrapper.findComponent(RouterLinkStub).text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/home')
+    })
+  })
+})

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -146,6 +146,22 @@ describe('Static Pages routing', () => {
     expect(wrapper.html()).toContain('処理名で検索')
   })
 
+  it('「カテゴリーで検索」ページに遷移すること', async () => {
+    router.push('/static_pages/category')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router]
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('カテゴリーで検索')
+  })
+
   describe('パラメータにnameを指定した場合', () => {
     it('nameを含むパスの「表面処理の検索結果」ページに遷移すること', async () => {
       router.push('/static_pages/name/search_results')

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -164,19 +164,47 @@ describe('Static Pages routing', () => {
 
   describe('パラメータにnameを指定した場合', () => {
     it('nameを含むパスの「表面処理の検索結果」ページに遷移すること', async () => {
-      router.push('/static_pages/name/search_results')
-  
-      await router.isReady()
-  
+      router.push({
+        name: 'SearchResults',
+        params: { searchMethod: 'name' },
+        query: { keyword: 'めっき' }
+      })
+
+      await flushPromises()
+
       const wrapper = mount(App, {
         global: {
           plugins: [router]
         }
       })
-  
+
       await flushPromises()
-  
+
       expect(wrapper.html()).toContain('表面処理の検索結果')
+      expect(wrapper.findComponent('#link_research').props().to).toBe('/static_pages/name')
+    })
+  })
+
+  describe('パラメータにcategoryを指定した場合', () => {
+    it('categoryを含むパスの「表面処理の検索結果」ページに遷移すること', async () => {
+      router.push({
+        name: 'SearchResults',
+        params: { searchMethod: 'category' },
+        query: { keyword: 'めっき' }
+      })
+
+      await flushPromises()
+
+      const wrapper = mount(App, {
+        global: {
+          plugins: [router]
+        }
+      })
+
+      await flushPromises()
+
+      expect(wrapper.html()).toContain('表面処理の検索結果')
+      expect(wrapper.findComponent('#link_research').props().to).toBe('/static_pages/category')
     })
   })
 })


### PR DESCRIPTION
## 概要
Rails ビューの static_pages/category と search_results/category を Vue.js でリファインする。
コンポーネント名：StaticPagesCategoryView.vue
テスト名：StaticPagesCategoryView.test.js

## 実装
- backend
  - [x] コントローラ
  - [x] ルーティング
  - [x] モデル
- frontend
  - [x] SaticPagesCategoryView コンポーネント
  - [x] ルーティング
  - [x] リクエスト・レスポンス
  - [x] SearchResultsView コンポーネント
  - [x] ルーティング
  - [x] リクエスト・レスポンス