### PR TITLE
メーカーで検索

### DIFF
--- a/backend/app/controllers/searches_controller.rb
+++ b/backend/app/controllers/searches_controller.rb
@@ -18,4 +18,14 @@ class SearchesController < ApplicationController
       keyword: keyword
     }
   end
+
+  def maker_search
+    samples = Sample.maker_search(params[:keyword])
+    keyword = params[:keyword]
+
+    render json: {
+      samples: samples,
+      keyword: keyword
+    }
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   get '/name_search',     to: 'searches#name_search'
   get '/category_search', to: 'searches#category_search'
+  get '/maker_search', to: 'searches#maker_search'
 
   resources :categories
   resources :makers

--- a/backend/db/migrate/20250505012249_remove_picture_from_samples.rb
+++ b/backend/db/migrate/20250505012249_remove_picture_from_samples.rb
@@ -1,0 +1,5 @@
+class RemovePictureFromSamples < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :samples, :picture, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_24_112507) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_05_012249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,7 +79,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_24_112507) do
     t.string "maker"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "picture"
     t.string "hardness"
     t.string "film_thickness"
     t.string "feature"

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -32,7 +32,7 @@ SAMPLES = [
     hardness: "析出状態の皮膜硬度でHV550～HV700、熱処理後の皮膜硬度はHV950程度",
     film_thickness: "通常は3～5μm、厚めの場合は20～50μmまで可能",
     feature: "耐食性・耐摩耗性・耐薬品性・耐熱性",
-    picture: "electroless_nickel_plating" },
+    image_file: "electroless_nickel_plating" },
 
   { name: "白金めっき",
     category: "めっき",
@@ -40,7 +40,7 @@ SAMPLES = [
     hardness: "Hv300～Hv400程度",
     film_thickness: "水素水生成器用の白金電極では0.5～2.0μm、装飾品では0.1～0.5μm程度",
     feature: "耐蝕性・導電性・耐摩耗性・耐熱性",
-    picture: "white_silver_plating" },
+    image_file: "white_silver_plating" },
 
   { name: "金めっき",
     category: "めっき",
@@ -48,7 +48,7 @@ SAMPLES = [
     hardness: "HV60～80程度",
     film_thickness: "下地ニッケルめっきは3～5μm、金めっきは0.1～1.0μm",
     feature: "耐食性・耐酸化性・電気抵抗性",
-    picture: "gold_plate" },
+    image_file: "gold_plate" },
 
   { name: "銀めっき",
     category: "めっき",
@@ -56,7 +56,7 @@ SAMPLES = [
     hardness: "HV60～80程度",
     film_thickness: "0.1～3μm程度",
     feature: "耐摩耗性・潤滑性・耐食性・導電性",
-    picture: "silver_plating" },
+    image_file: "silver_plating" },
 
   { name: "銅めっき",
     category: "めっき",
@@ -64,7 +64,7 @@ SAMPLES = [
     hardness: "無光沢でHv80～120、光沢でHv80～200程度",
     film_thickness: "0.2～2μm程度",
     feature: "抗菌性・密着性",
-    picture: "copper_plating" },
+    image_file: "copper_plating" },
 
   { name: "亜鉛めっき",
     category: "めっき",
@@ -72,7 +72,7 @@ SAMPLES = [
     hardness: "シアン浴でHv60～90、ジンケート浴でHv100～140、塩化浴でHv60～90",
     film_thickness: "5～20μm程度",
     feature: "耐食性・耐腐食性・密着性",
-    picture: "zinc_plating" },
+    image_file: "zinc_plating" },
 
   { name: "錫めっき",
     category: "めっき",
@@ -80,7 +80,7 @@ SAMPLES = [
     hardness: "Hv9.5～10.5程度",
     film_thickness: "光沢スズめっきで3～10μm、無光沢スズめっきで5～20μm程度",
     feature: "耐食性・潤滑性・摺動性",
-    picture: "tin_plating" },
+    image_file: "tin_plating" },
 
   { name: "ニッケルめっき",
     category: "めっき",
@@ -88,7 +88,7 @@ SAMPLES = [
     hardness: "Hv350 ～500程度",
     film_thickness: "3～30μm程度",
     feature: "耐食性・耐薬品性・耐熱性",
-    picture: "nickel_plating" },
+    image_file: "nickel_plating" },
 
   { name: "クロムめっき",
     category: "めっき",
@@ -96,7 +96,7 @@ SAMPLES = [
     hardness: "Hv700～1,000程度",
     film_thickness: "0.1～0.2μm程度",
     feature: "耐食性・耐摩耗性・耐衝撃性",
-    picture: "chrome_plating" },
+    image_file: "chrome_plating" },
 
   { name: "黒色クロムめっき",
     category: "めっき",
@@ -104,7 +104,7 @@ SAMPLES = [
     hardness: "装飾用でHv550～640、工業用でHv800～1,000程度",
     film_thickness: "3～8μm程度",
     feature: "低反射性・熱吸収性・導電性・耐食性",
-    picture: "black_chrome_plating" },
+    image_file: "black_chrome_plating" },
 
   { name: "白アルマイト",
     category: "陽極酸化",
@@ -112,7 +112,7 @@ SAMPLES = [
     hardness: "Hv200程度",
     film_thickness: "6～10µm程度",
     feature: "耐摩耗性・耐電圧性",
-    picture: "white_anodized_aluminum" },
+    image_file: "white_anodized_aluminum" },
 
   { name: "黒アルマイト",
     category: "陽極酸化",
@@ -120,7 +120,7 @@ SAMPLES = [
     hardness: "Hv200程度",
     film_thickness: "5～20μm程度",
     feature: "反射防止性・熱伝導性・光選択吸収性",
-    picture: "black_anodized_aluminum" },
+    image_file: "black_anodized_aluminum" },
 
   { name: "硬質アルマイト",
     category: "陽極酸化",
@@ -128,7 +128,7 @@ SAMPLES = [
     hardness: "Hv450〜500程度",
     film_thickness: "20〜30μm程度",
     feature: "耐摩耗性",
-    picture: "hard_anodized_aluminum" },
+    image_file: "hard_anodized_aluminum" },
 
   { name: "ユニクロクロメート",
     category: "化成",
@@ -136,7 +136,7 @@ SAMPLES = [
     hardness: "Hv70～100程度",
     film_thickness: "0.1～0.3μｍ程度",
     feature: "耐食性・耐摩耗性・導電性・潤滑性",
-    picture: "unichromate" },
+    image_file: "unichromate" },
 
   { name: "有色クロメート",
     category: "化成",
@@ -144,7 +144,7 @@ SAMPLES = [
     hardness: "Hv70～100程度",
     film_thickness: "0.1～0.3μｍ程度",
     feature: "耐食性・耐摩耗性・導電性・潤滑性",
-    picture: "colored_chromate" },
+    image_file: "colored_chromate" },
 
   { name: "黒クロメート",
     category: "化成",
@@ -152,7 +152,7 @@ SAMPLES = [
     hardness: "0.1～0.3μｍ程度",
     film_thickness: "Hv70～100程度",
     feature: "耐食性・耐摩耗性・導電性・潤滑性",
-    picture: "black_chromate" },
+    image_file: "black_chromate" },
 
   { name: "緑クロメート",
     category: "化成",
@@ -160,7 +160,7 @@ SAMPLES = [
     hardness: "Hv70～100程度",
     film_thickness: "0.1～0.3μｍ程度",
     feature: "耐食性・耐摩耗性・導電性・潤滑性",
-    picture: "green_chromate" },
+    image_file: "green_chromate" },
 
   { name: "四三酸化鉄皮膜",
     category: "化成",
@@ -168,7 +168,7 @@ SAMPLES = [
     hardness: "対象外",
     film_thickness: "0.2〜1μm",
     feature: "装飾性・反射防止",
-    picture: "iron_tetroxide_film" },
+    image_file: "iron_tetroxide_film" },
 
   { name: "パーカー",
     category: "化成",
@@ -176,7 +176,7 @@ SAMPLES = [
     hardness: "Hv400～1300程度",
     film_thickness: "1～20μm程度",
     feature: "耐摩耗性・密着性・耐食性・耐熱性",
-    picture: "hooded sweatshirt" },
+    image_file: "hooded sweatshirt" },
 
   { name: "TiN",
     category: "コーティング",
@@ -184,7 +184,7 @@ SAMPLES = [
     hardness: "Hv2000程度",
     film_thickness: "2～4μm程度",
     feature: "耐摩耗性・離型性",
-    picture: "titanium_coating" },
+    image_file: "titanium_coating" },
 
   { name: "TiCN",
     category: "コーティング",
@@ -192,7 +192,7 @@ SAMPLES = [
     hardness: "Hv3000～4000程度",
     film_thickness: "2μm",
     feature: "耐摩耗性・耐食性・耐熱性",
-    picture: "titanium_ceramic_coating" },
+    image_file: "titanium_ceramic_coating" },
 
   { name: "TiAlN",
     category: "コーティング",
@@ -200,7 +200,7 @@ SAMPLES = [
     hardness: "Hv2400～2600程度",
     film_thickness: "2～4µm程度",
     feature: "耐熱性・耐酸化性・耐摩耗性・",
-    picture: "titanium_aluminum_coating" },
+    image_file: "titanium_aluminum_coating" },
 
   { name: "AlCrN",
     category: "コーティング",
@@ -208,7 +208,7 @@ SAMPLES = [
     hardness: "Hv2000～2500程度",
     film_thickness: "3～5μm程度",
     feature: "耐摩耗性・耐熱性",
-    picture: "aluminum_chrome_coating" },
+    image_file: "aluminum_chrome_coating" },
 
   { name: "CrN",
     category: "コーティング",
@@ -216,7 +216,7 @@ SAMPLES = [
     hardness: "Hv1800程度",
     film_thickness: "2～4μm程度",
     feature: "耐摩耗性・耐食性・潤滑性・耐熱性",
-    picture: "chromium_nitride_coating" },
+    image_file: "chromium_nitride_coating" },
 
   { name: "DLC",
     category: "コーティング",
@@ -224,7 +224,7 @@ SAMPLES = [
     hardness: "Hv3000～6000程度",
     film_thickness: "1～3μm程度",
     feature: "耐摩耗性・摺動性・耐食性",
-    picture: "diamond_like_carbon" },
+    image_file: "diamond_like_carbon" },
 
   { name: "ブラスト",
     category: "表面硬化",
@@ -232,7 +232,7 @@ SAMPLES = [
     hardness: "対象外",
     film_thickness: "対象外",
     feature: "耐摩耗性・摺動性・潤滑性",
-    picture: "blast" },
+    image_file: "blast" },
 
   { name: "WPC",
     category: "表面硬化",
@@ -240,7 +240,7 @@ SAMPLES = [
     hardness: "対象外",
     film_thickness: "対象外",
     feature: "耐摩耗性・摺動性・潤滑性",
-    picture: "wonder_process_craft" },
+    image_file: "wonder_process_craft" },
 
   { name: "レイデント",
     category: "めっき",
@@ -248,7 +248,7 @@ SAMPLES = [
     hardness: "Hv350程度",
     film_thickness: "1～2μm程度",
     feature: "薄膜性・防錆性・光学特性・装飾性",
-    picture: "raident" },
+    image_file: "raident" },
 
   { name: "パルソナイト",
     category: "表面硬化",
@@ -256,7 +256,7 @@ SAMPLES = [
     hardness: "表面硬度は炭素鋼Hv400〜500程度、ステンレス材でHv900程度",
     film_thickness: "3～10μm程度",
     feature: "耐食性・耐摩耗性・平滑性",
-    picture: "palsonite" },
+    image_file: "palsonite" },
 
   { name: "タフトライド",
     category: "表面硬化",
@@ -264,7 +264,7 @@ SAMPLES = [
     hardness: "Hv570前後",
     film_thickness: "0.01～0.3μm程度",
     feature: "耐摩耗性、耐疲労性、耐食性、耐かじり性",
-    picture: "tufted_ride" },
+    image_file: "tufted_ride" },
 
   { name: "キリンコートS",
     category: "表面硬化",
@@ -272,7 +272,7 @@ SAMPLES = [
     hardness: "表面硬度はHv400～1300程度",
     film_thickness: "0.01～0.04μm程度",
     feature: "平滑性・耐摩耗性・密着性",
-    picture: "kirin_coat_s" },
+    image_file: "kirin_coat_s" },
 
   { name: "カナック",
     category: "表面硬化",
@@ -280,7 +280,7 @@ SAMPLES = [
     hardness: "Hv800～1400程度",
     film_thickness: "寸法変化は0～5µm程度",
     feature: "耐食性・耐熱性・摺動性",
-    picture: "canac" }
+    image_file: "canac" }
 ]
 
 SAMPLES.each do |sample|
@@ -291,7 +291,7 @@ SAMPLES.each do |sample|
                  hardness: sample[:hardness],
                  film_thickness: sample[:film_thickness],
                  feature: sample[:feature],
-                 picture: File.open("app/assets/images/#{sample[:picture]}.jpeg"))
+                 image: File.open("app/assets/images/#{sample[:image_file]}.jpeg"))
 end
 
 100.times do |n|

--- a/backend/spec/factories/samples.rb
+++ b/backend/spec/factories/samples.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     category { "めっき" }
     color { "コールド" }
     maker { "ヘッティンガー株式会社" }
-    picture { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
+    image { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
     hardness { '析出状態の皮膜硬度でHV550～HV700、熱処理後の皮膜硬度はHV950程度' }
     film_thickness { '通常は3～5μm、厚めの場合は20～50μmまで可能' }
     feature { '耐食性・耐摩耗性・耐薬品性・耐熱性' }
@@ -15,18 +15,10 @@ FactoryBot.define do
     category { "めっき" }
     color { "ゴールド" }
     maker { "ヘッティンガー株式会社" }
-    picture { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
+    image { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
     hardness { '析出状態の皮膜硬度でHV550～HV700、熱処理後の皮膜硬度はHV950程度' }
     film_thickness { '通常は3～5μm、厚めの場合は20～50μmまで可能' }
     feature { '耐食性・耐摩耗性・耐薬品性・耐熱性' }
-
-    after(:build) do |sample|
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-    end
   end
 
   factory :anodised_aluminium, class: Sample do
@@ -34,18 +26,10 @@ FactoryBot.define do
     category { "陽極酸化" }
     color { "ホワイト" }
     maker { "有限会社村田保険" }
-    picture { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
+    image { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
     hardness { 'Hv200程度' }
     film_thickness { '5〜10µm程度' }
     feature { '電気絶縁性・耐食性・耐摩耗性' }
-
-    after(:build) do |sample|
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-    end
   end
 
   factory :chromate, class: Sample do
@@ -53,28 +37,9 @@ FactoryBot.define do
     category { "化成" }
     color { "ブラック" }
     maker { "株式会社中川鉱業" }
-    picture { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
+    image { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
     hardness { 'Hv200～350程度' }
     film_thickness { '0.1～3μm程度' }
     feature { '導電性・耐傷性・絶縁性・耐食性' }
-
-    after(:build) do |sample|
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-    end
-  end
-
-  factory :invalid_image_sample, class: Sample do
-    name { "無電解ニッケルめっき" }
-    category { "めっき" }
-    color { "コールド" }
-    maker { "ヘッティンガー株式会社" }
-    picture { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/invalid_image.jpeg')) }
-    hardness { '析出状態の皮膜硬度でHV550～HV700、熱処理後の皮膜硬度はHV950程度' }
-    film_thickness { '通常は3～5μm、厚めの場合は20～50μmまで可能' }
-    feature { '耐食性・耐摩耗性・耐薬品性・耐熱性' }
   end
 end

--- a/backend/spec/models/comment_spec.rb
+++ b/backend/spec/models/comment_spec.rb
@@ -3,16 +3,7 @@ require 'rails_helper'
 RSpec.describe Comment, type: :model do
   describe 'validation' do
     before do
-      sample = FactoryBot.build(:sample)
-
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-
-      sample.save
-      
+      FactoryBot.create(:sample)      
       @comment = FactoryBot.build(:comment)
     end
 

--- a/backend/spec/models/sample_spec.rb
+++ b/backend/spec/models/sample_spec.rb
@@ -4,13 +4,7 @@ RSpec.describe Sample, type: :model do
   describe 'Association' do
     describe 'has_one_attached' do
       it '画像を添付できること' do
-        sample = FactoryBot.build(:sample)
-
-        sample.image.attach(
-          io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-          filename: 'test.jpg',
-          content_type: 'image/jpg'
-        )
+        sample = FactoryBot.create(:sample)
 
         expect(sample.image).to be_attached
       end
@@ -20,12 +14,6 @@ RSpec.describe Sample, type: :model do
   describe 'Validation' do
     before do
       @sample = FactoryBot.build(:sample)
-
-      @sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
     end
 
     it 'sampleが有効であること' do
@@ -49,6 +37,11 @@ RSpec.describe Sample, type: :model do
 
     it 'makerが存在すること' do
       @sample.maker = ''
+      expect(@sample).to_not be_valid
+    end
+
+    it 'imageが存在すること' do
+      @sample.image = nil
       expect(@sample).to_not be_valid
     end
 
@@ -147,15 +140,7 @@ RSpec.describe Sample, type: :model do
     describe '#image_url' do
       context '画像が添付されている場合' do
         it '画像のURLを返すこと' do
-          sample = FactoryBot.build(:sample)
-
-          sample.image.attach(
-            io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-            filename: 'test.jpg',
-            content_type: 'image/jpg'
-          )
-
-          sample.save
+          sample = FactoryBot.create(:sample)
 
           expect(sample.image_url).to be_present
           expect(sample.image_url).to include('test.jpg')
@@ -164,7 +149,8 @@ RSpec.describe Sample, type: :model do
 
       context '画像が添付されていない場合' do
         it 'nilを返すこと' do
-          sample = FactoryBot.build(:sample)
+          sample = FactoryBot.create(:sample)
+          sample.image.purge
 
           expect(sample.image_url).to be_nil
         end

--- a/backend/spec/requests/comments_spec.rb
+++ b/backend/spec/requests/comments_spec.rb
@@ -3,16 +3,7 @@ require 'rails_helper'
 RSpec.describe "Comments API", type: :request do
   describe '#index' do
     before do
-      sample = FactoryBot.build(:sample)
-
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-
-      sample.save
-
+      FactoryBot.create(:sample)
       FactoryBot.create_list(:comment, 10)
       @comment = Comment.first
     end
@@ -31,16 +22,7 @@ RSpec.describe "Comments API", type: :request do
 
   describe '#show' do
     before do
-      sample = FactoryBot.build(:sample)
-
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-
-      sample.save
-
+      FactoryBot.create(:sample)
       @comment = FactoryBot.create(:comment)
     end
 
@@ -60,15 +42,7 @@ RSpec.describe "Comments API", type: :request do
 
   describe "#create" do
     before do
-      @sample = FactoryBot.build(:sample)
-
-      @sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-
-      @sample.save
+      @sample = FactoryBot.create(:sample)
     end
 
     context '有効なコメント情報で登録したとき' do
@@ -114,16 +88,7 @@ RSpec.describe "Comments API", type: :request do
 
   describe '#update' do
     before do
-      sample = FactoryBot.build(:sample)
-
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-
-      sample.save
-      
+      FactoryBot.create(:sample)
       @comment = FactoryBot.create(:comment)
     end
 
@@ -151,16 +116,7 @@ RSpec.describe "Comments API", type: :request do
 
   describe '#destroy' do
     before do
-      sample = FactoryBot.build(:sample)
-
-      sample.image.attach(
-        io: File.open(Rails.root + 'spec/fixtures/test.jpg'),
-        filename: 'test.jpg',
-        content_type: 'image/jpg'
-      )
-
-      sample.save
-
+      FactoryBot.create(:sample)
       @comment = FactoryBot.create(:comment)
     end
 

--- a/backend/spec/requests/samples_spec.rb
+++ b/backend/spec/requests/samples_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Samples API", type: :request do
       expect(json).to include(:category)
       expect(json).to include(:color)
       expect(json).to include(:maker)
-      expect(json).to include(:picture)
+      # expect(json).to include(:picture)
       expect(json).to include(:hardness)
       expect(json).to include(:film_thickness)
       expect(json).to include(:feature)

--- a/backend/spec/requests/searches_spec.rb
+++ b/backend/spec/requests/searches_spec.rb
@@ -38,20 +38,20 @@ RSpec.describe "Searches", type: :request do
     end
   end
 
-  # describe '#maker_search' do
-  #   it 'レスポンスが正常であること' do
-  #     get category_maker_search_path
-  #     expect(response).to have_http_status(:success)
-  #   end
+  describe '#maker_search' do
+    it 'レスポンスのステータスがsuccessであること' do
+      get '/maker_search'
+      expect(response).to have_http_status(:success)
+    end
 
-  #   it 'タイトルが表示されること' do
-  #     get category_maker_search_path
-  #     expect(response.body).to include('<title>メーカー名での検索結果</title>')
-  #   end
+    it 'レスポンスのjsonに:samplesと:keywordが含まれていること' do
+      get '/maker_search', params: { keyword: '株式会社' }
+      json = JSON.parse(response.body, symbolize_names: true)
 
-  #   it '"無電解ニッケルめっき"が表示されること' do
-  #     get category_maker_search_path, params: { keyword: '株式会社' }
-  #     expect(response.body).to include("無電解ニッケルめっき")
-  #   end
-  # end
+      expect(json.include?(:samples)).to be(true)
+      expect(json.include?(:keyword)).to be(true)
+      expect(json[:samples].count).to eq(5)
+      expect(json[:keyword]).to eq('株式会社')
+    end
+  end
 end

--- a/frontend/src/components/HomeView.vue
+++ b/frontend/src/components/HomeView.vue
@@ -41,7 +41,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">メーカー名で検索</h5>
             <p class="card-text">メーカー名を入力して表面処理を検索します。</p>
-            <RouterLink to="#" class="card-link">検索ページへ</RouterLink>
+            <RouterLink to="/static_pages/maker" class="card-link">検索ページへ</RouterLink>
           </div>
         </div>
       </div>

--- a/frontend/src/components/static_pages/StaticPagesMakerView.vue
+++ b/frontend/src/components/static_pages/StaticPagesMakerView.vue
@@ -1,12 +1,27 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const keyword = ref('')
+const router = useRouter()
+
+const submitSearch = () => {
+  router.push({
+    name: 'SearchResults',
+    params: { searchMethod: 'maker' },
+    query: { keyword: keyword.value }
+  })
+}
+</script>
+
 <template>
   <div class="container text-center w-25">
     <h3 class="mt-5 mb-5">
       メーカー名で検索
     </h3>
-    <!-- <form v-on:submit.prevent="submitSearch"> -->
-    <form>
-      <!-- v-model="keyword" -->
+    <form v-on:submit.prevent="submitSearch">
       <input
+        v-model="keyword"
         type="text"
         class="form-control mb-3"
         placeholder="キーワードをここに入力"

--- a/frontend/src/components/static_pages/StaticPagesMakerView.vue
+++ b/frontend/src/components/static_pages/StaticPagesMakerView.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="container text-center w-25">
+    <h3 class="mt-5 mb-5">
+      メーカー名で検索
+    </h3>
+    <!-- <form v-on:submit.prevent="submitSearch"> -->
+    <form>
+      <!-- v-model="keyword" -->
+      <input
+        type="text"
+        class="form-control mb-3"
+        placeholder="キーワードをここに入力"
+      />
+      <button type="submit" class="btn btn-secondary form-control mb-5">検索</button>
+    </form>
+    <div>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -22,6 +22,7 @@ import SamplesNewView from './components/samples/SamplesNewView.vue'
 import SamplesEditView from './components/samples/SamplesEditView.vue'
 import StaticPagesNameView from './components/static_pages/StaticPagesNameView.vue'
 import StaticPagesCategoryView from './components/static_pages/StaticPagesCategoryView.vue'
+import StaticPagesMakerView from './components/static_pages/StaticPagesMakerView.vue'
 import SearchResultsView from './components/search_results/SearchResultsView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
@@ -48,7 +49,8 @@ const routes = [
   { path: '/samples/new', component: SamplesNewView },
   { path: '/samples/:id/edit', component: SamplesEditView },
   { path: '/static_pages/name', component: StaticPagesNameView },
-  { path: '/static_pages/category', component: StaticPagesCategoryView }, 
+  { path: '/static_pages/category', component: StaticPagesCategoryView },
+  { path: '/static_pages/maker', component: StaticPagesMakerView },
   {
     path: '/static_pages/:searchMethod(name|category|maker)/search_results',
     component: SearchResultsView,

--- a/frontend/test/component/HomeView.test.js
+++ b/frontend/test/component/HomeView.test.js
@@ -64,7 +64,7 @@ describe('HomeView', () => {
 
       expect(links[0].attributes('href')).toBe('/static_pages/name')
       expect(links[1].attributes('href')).toBe('/static_pages/category')
-      expect(links[2].attributes('href')).toBe('#')
+      expect(links[2].attributes('href')).toBe('/static_pages/maker')
       expect(links[3].attributes('href')).toBe('#')
       expect(links[4].attributes('href')).toBe('/samples')
       expect(links[5].attributes('href')).toBe('/categories')

--- a/frontend/test/component/search_results/SearchResultsView.test.js
+++ b/frontend/test/component/search_results/SearchResultsView.test.js
@@ -126,7 +126,7 @@ describe('SearchResultsNameView', () => {
     })
   })
 
-  describe('ルートパラメータ毎の表示', () => {
+  describe('ルートパラメータ別の表示', () => {
     describe('ルートパラメータがnameの場合', () => {
       it('再検索リンクのパスにnameが含まれていること', async () => {
         useRoute.mockReturnValue({
@@ -184,6 +184,36 @@ describe('SearchResultsNameView', () => {
         await flushPromises()
 
         expect(wrapper.findComponent({ ref: 'linkResearch' }).props().to).toBe('/static_pages/category')
+      })
+    })
+
+    describe('ルートパラメータがmakerの場合', () => {
+      it('再検索リンクのパスにmakerが含まれていること', async () => {
+        useRoute.mockReturnValue({
+          params: { searchMethod: 'maker' },
+          query: { keyword: '株式会社' }
+        })
+
+        axios.get.mockResolvedValue({
+          data: {
+            keyword: '株式会社',
+            samples: [
+              { id: 1, name: 'ハードクロムめっき', maker: '株式会社テスト', category: 'めっき' }
+            ],
+          }
+        })
+
+        const wrapper = mount(SearchResultsView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
+
+        await flushPromises()
+
+        expect(wrapper.findComponent({ ref: 'linkResearch' }).props().to).toBe('/static_pages/maker')
       })
     })
   })

--- a/frontend/test/component/static_pages/StaticPagesMakerView.test.js
+++ b/frontend/test/component/static_pages/StaticPagesMakerView.test.js
@@ -1,11 +1,30 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import StaticPagesMakerView from '@/components/static_pages/StaticPagesMakerView.vue'
+
+const pushMock = vi.fn()
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual('vue-router')
+
+  return {
+    ...actual,
+    useRouter: () => {
+      return {
+        push: pushMock
+      }
+    }
+  }
+})
+
+beforeEach(() => {
+  pushMock.mockClear()
+})
 
 describe('StaticPagesMakerView', () => {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(async () => {
     wrapper = mount(StaticPagesMakerView, {
       global: {
         stubs: {
@@ -13,6 +32,8 @@ describe('StaticPagesMakerView', () => {
         }
       }
     })
+
+    await flushPromises()
   })
 
   describe('DOMの構造', () => {
@@ -34,6 +55,24 @@ describe('StaticPagesMakerView', () => {
       expect(wrapper.findComponent({ ref: 'linkHome' }).exists()).toBe(true)
       expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
       expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
+    })
+  })
+
+  describe('API通信', () => {
+    describe('有効な検索文字列を入力して送信した場合', () => {
+      it('/static_pages/maker/search_resultsページが呼び出されること', async () => {
+        await wrapper.find('input').setValue('株式会社')
+        expect(wrapper.find('input').element.value).toBe('株式会社')
+
+        await wrapper.find('form').trigger('submit.prevent')
+        await flushPromises()
+
+        expect(pushMock).toHaveBeenCalledWith({
+          name: 'SearchResults',
+          params: { searchMethod: 'maker' },
+          query: { keyword: '株式会社' }
+        })
+      })
     })
   })
 })

--- a/frontend/test/component/static_pages/StaticPagesMakerView.test.js
+++ b/frontend/test/component/static_pages/StaticPagesMakerView.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import StaticPagesMakerView from '@/components/static_pages/StaticPagesMakerView.vue'
+
+describe('StaticPagesMakerView', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(StaticPagesMakerView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
+  })
+
+  describe('DOMの構造', () => {
+    it('見出しが存在すること', () => {
+      expect(wrapper.find('h3').exists()).toBe(true)
+      expect(wrapper.find('h3').exists()).toBe(true)
+    })
+
+    it('テキスト入力フィールドが存在すること', () => {
+      expect(wrapper.find('input').exists()).toBe(true)
+    })
+
+    it('検索ボタンが存在すること', () => {
+      expect(wrapper.find('button').exists()).toBe(true)
+      expect(wrapper.find('button').text()).toBe('検索')
+    })
+
+    it('外部リンクが存在すること', () => {
+      expect(wrapper.findComponent({ ref: 'linkHome' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
+    })
+  })
+})

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -162,6 +162,22 @@ describe('Static Pages routing', () => {
     expect(wrapper.html()).toContain('カテゴリーで検索')
   })
 
+  it('「メーカー名で検索」ページに遷移すること', async () => {
+    router.push('/static_pages/maker')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router]
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('メーカー名で検索')
+  })
+
   describe('パラメータにnameを指定した場合', () => {
     it('nameを含むパスの「表面処理の検索結果」ページに遷移すること', async () => {
       router.push({

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -223,4 +223,27 @@ describe('Static Pages routing', () => {
       expect(wrapper.findComponent('#link_research').props().to).toBe('/static_pages/category')
     })
   })
+
+  describe('パラメータにmakerを指定した場合', () => {
+    it('makerを含むパスの「表面処理の検索結果」ページに遷移すること', async () => {
+      router.push({
+        name: 'SearchResults',
+        params: { searchMethod: 'maker' },
+        query: { keyword: '株式会社' }
+      })
+
+      await flushPromises()
+
+      const wrapper = mount(App, {
+        global: {
+          plugins: [router]
+        }
+      })
+
+      await flushPromises()
+
+      expect(wrapper.html()).toContain('表面処理の検索結果')
+      expect(wrapper.findComponent('#link_research').props().to).toBe('/static_pages/maker')
+    })
+  })
 })

--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,8 @@
-# Exported from Render on 2025-04-04T20:34:06Z
+# Exported from Render on 2025-05-05T01:35:03Z
 databases:
 - name: surface-treatment-manager
-  databaseName: surface_treatment_manager_6w8p
-  user: surface_treatment_manager_6w8p_user
+  databaseName: surface_treatment_manager_bixl
+  user: surface_treatment_manager_bixl_user
   plan: free
   region: singapore
   ipAllowList:


### PR DESCRIPTION
## 概要
Rails ビューの searches_result/maker を Vue.js でリファインする。
コンポーネント名：StaticPagesMakerView.vue
テスト名：StaticPagesMakerView.test.js

## 実装
- backend
  - [x] コントローラ
  - [x] ルーティング
  - [x] モデル（.maker_searchの動作確認のみ）
  - [x] curl でレスポンスの確認
  - [x] テスト
- frontend
  - [x] コンポーネント
  - [x] ルーティング
  - [x] リクエスト・レスポンス
  - [x] 外部リンク
- hotfix
  - picture カラムの削除
    - [x] factories/samples.rb の修正
    - [x] spec/models/sample_spec.rb の修正
    - [x] spec/requests/sample_spec.rb の修正
    - [x] spec/models/comment_spec.rb の修正
    - [x] spec/requests/comment_spec.rb の修正
    - [x] db/seeds.rb の修正
    - [x] sample リソースの picture カラムを削除
    - [x] Render.com の PostgreSQL を再セットアップ
    - [x] render.yaml の差替