### PR TITLE
サンプル一覧から検索の実装

### DIFF
--- a/backend/app/controllers/searches_controller.rb
+++ b/backend/app/controllers/searches_controller.rb
@@ -28,4 +28,10 @@ class SearchesController < ApplicationController
       keyword: keyword
     }
   end
+
+  def list_search
+    samples = Sample.order(:id)
+
+    render json: samples
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,7 +7,8 @@ Rails.application.routes.draw do
 
   get '/name_search',     to: 'searches#name_search'
   get '/category_search', to: 'searches#category_search'
-  get '/maker_search', to: 'searches#maker_search'
+  get '/maker_search',    to: 'searches#maker_search'
+  get '/list_search',     to: 'searches#list_search'
 
   resources :categories
   resources :makers

--- a/backend/spec/requests/searches_spec.rb
+++ b/backend/spec/requests/searches_spec.rb
@@ -54,4 +54,18 @@ RSpec.describe "Searches", type: :request do
       expect(json[:keyword]).to eq('株式会社')
     end
   end
+
+  describe '#list_search' do
+    it 'レスポンスのステータスがsuccessであること' do
+      get '/list_search'
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'レスポンスのjsonにサンプルが5件含まれていること' do
+      get '/list_search'
+      json = JSON.parse(response.body)
+
+      expect(json.count).to eq(5)
+    end
+  end
 end

--- a/frontend/src/components/HomeView.vue
+++ b/frontend/src/components/HomeView.vue
@@ -51,7 +51,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">処理一覧から検索</h5>
             <p class="card-text">表面処理一覧から目的の処理を検索します。</p>
-            <RouterLink to="#" class="card-link">検索ページへ</RouterLink>
+            <RouterLink to="/list_search_results" class="card-link">検索ページへ</RouterLink>
           </div>
         </div>
       </div>

--- a/frontend/src/components/search_results/SearchResultsListView.vue
+++ b/frontend/src/components/search_results/SearchResultsListView.vue
@@ -1,16 +1,45 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const samplesWithImage = ref([])
+const samplesWithoutImage = ref([])
+
+const fetchSearchResults = async () => {
+  const response = await axios.get(`${API_BASE_URL}/list_search`)
+  samplesWithoutImage.value = response.data
+
+  for (let i = 0; i < samplesWithoutImage.value.length; i++) {
+    const response = await axios.get(`${API_BASE_URL}/samples/${samplesWithoutImage.value[i].id}`)
+    samplesWithImage.value.push(response.data)
+  }
+}
+
+onMounted(() => {
+  fetchSearchResults()
+})
+</script>
+
 <template>
   <div class="container">
     <h3 class="text-center mt-5 mb-5">表面処理一覧</h3>
 
     <div class="album">
       <div class="row row-cols-5 g-3">
-        <div class="col">
+        <div v-for="sample in samplesWithImage" v-bind:key="sample.id" class="col">
           <div class="card">
-            <img src="@/assets/images/electroless_nickel_plating.png" class="card-img-top" alt="Sample Image" width="100%" height="225">
+            <img
+              v-bind:src="sample.image_url"
+              class="card-img-top"
+              alt="Sample Image"
+              width="100%"
+              height="225"
+            >
             <div class="card-body">
-              <h5 class="card-title mb-3">無電解ニッケルめっき</h5>
+              <h5 class="card-title mb-3">{{ sample.name }}</h5>
               <p class="card-text">電気を使わずに化学反応を利用して金属や樹脂などの表面にニッケルの薄膜を形成する表面処理技術です。</p>
-              <a href="#" class="btn btn-primary">詳細へ</a>
+              <RouterLink v-bind:to="`/samples/${sample.id}`" class="btn btn-primary" v-bind:ref="`linkSample${sample.id}`">詳細へ</RouterLink>
             </div>
           </div>
         </div>

--- a/frontend/src/components/search_results/SearchResultsListView.vue
+++ b/frontend/src/components/search_results/SearchResultsListView.vue
@@ -9,12 +9,12 @@ const samplesWithoutImage = ref([])
 const fetchSearchResults = async () => {
   try {
     const response = await axios.get(`${API_BASE_URL}/list_search`)
-  samplesWithoutImage.value = response.data
+    samplesWithoutImage.value = response.data
 
-  for (let i = 0; i < samplesWithoutImage.value.length; i++) {
-    const response = await axios.get(`${API_BASE_URL}/samples/${samplesWithoutImage.value[i].id}`)
-    samplesWithImage.value.push(response.data)
-  }    
+    for (let i = 0; i < samplesWithoutImage.value.length; i++) {
+      const response = await axios.get(`${API_BASE_URL}/samples/${samplesWithoutImage.value[i].id}`)
+      samplesWithImage.value.push(response.data)
+    }    
   } catch (error) {
     console.error('検索結果の取得に失敗しました', error)
   }
@@ -43,7 +43,13 @@ onMounted(() => {
             <div class="card-body">
               <h5 class="card-title mb-3">{{ sample.name }}</h5>
               <p class="card-text">電気を使わずに化学反応を利用して金属や樹脂などの表面にニッケルの薄膜を形成する表面処理技術です。</p>
-              <RouterLink v-bind:to="`/samples/${sample.id}`" class="btn btn-primary" v-bind:ref="`linkSample${sample.id}`">詳細へ</RouterLink>
+              <RouterLink
+                v-bind:to="`/samples/${sample.id}`"
+                class="btn btn-primary"
+                v-bind:ref="`linkSample${sample.id}`"
+              >
+                詳細へ
+              </RouterLink>
             </div>
           </div>
         </div>

--- a/frontend/src/components/search_results/SearchResultsListView.vue
+++ b/frontend/src/components/search_results/SearchResultsListView.vue
@@ -7,12 +7,16 @@ const samplesWithImage = ref([])
 const samplesWithoutImage = ref([])
 
 const fetchSearchResults = async () => {
-  const response = await axios.get(`${API_BASE_URL}/list_search`)
+  try {
+    const response = await axios.get(`${API_BASE_URL}/list_search`)
   samplesWithoutImage.value = response.data
 
   for (let i = 0; i < samplesWithoutImage.value.length; i++) {
     const response = await axios.get(`${API_BASE_URL}/samples/${samplesWithoutImage.value[i].id}`)
     samplesWithImage.value.push(response.data)
+  }    
+  } catch (error) {
+    console.error('検索結果の取得に失敗しました', error)
   }
 }
 

--- a/frontend/src/components/search_results/SearchResultsListView.vue
+++ b/frontend/src/components/search_results/SearchResultsListView.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="container">
+    <h3 class="text-center mt-5 mb-5">表面処理一覧</h3>
+
+    <div class="album">
+      <div class="row row-cols-5 g-3">
+        <div class="col">
+          <div class="card">
+            <img src="@/assets/images/electroless_nickel_plating.png" class="card-img-top" alt="Sample Image" width="100%" height="225">
+            <div class="card-body">
+              <h5 class="card-title mb-3">無電解ニッケルめっき</h5>
+              <p class="card-text">電気を使わずに化学反応を利用して金属や樹脂などの表面にニッケルの薄膜を形成する表面処理技術です。</p>
+              <a href="#" class="btn btn-primary">詳細へ</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="d-flex justify-content-evenly mt-5 mb-5">
+      <RouterLink to="/home" id="link_home" ref="linkHome">メインメニューへ</RouterLink>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -24,6 +24,7 @@ import StaticPagesNameView from './components/static_pages/StaticPagesNameView.v
 import StaticPagesCategoryView from './components/static_pages/StaticPagesCategoryView.vue'
 import StaticPagesMakerView from './components/static_pages/StaticPagesMakerView.vue'
 import SearchResultsView from './components/search_results/SearchResultsView.vue'
+import SearchResultsListView from './components/search_results/SearchResultsListView.vue'
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -56,6 +57,7 @@ const routes = [
     component: SearchResultsView,
     name: 'SearchResults',
   },
+  { path: '/list_search_results', component: SearchResultsListView },
 ]
 
 const router = createRouter({

--- a/frontend/test/component/HomeView.test.js
+++ b/frontend/test/component/HomeView.test.js
@@ -65,7 +65,7 @@ describe('HomeView', () => {
       expect(links[0].attributes('href')).toBe('/static_pages/name')
       expect(links[1].attributes('href')).toBe('/static_pages/category')
       expect(links[2].attributes('href')).toBe('/static_pages/maker')
-      expect(links[3].attributes('href')).toBe('#')
+      expect(links[3].attributes('href')).toBe('/list_search_results')
       expect(links[4].attributes('href')).toBe('/samples')
       expect(links[5].attributes('href')).toBe('/categories')
       expect(links[6].attributes('href')).toBe('/makers')

--- a/frontend/test/component/search_results/SearchResultsListView.test.js
+++ b/frontend/test/component/search_results/SearchResultsListView.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import SearchResultsListView from '@/components/search_results/SearchResultsListView.vue'
+// import { RouterLink } from 'vue-router'
+
+describe('SearchResultsListView', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(SearchResultsListView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
+  })
+
+  describe('DOMの構造', () => {
+    it('見出しが存在すること', () => {
+      expect(wrapper.find('h3').exists()).toBe(true)
+      expect(wrapper.find('h3').text()).toBe('表面処理一覧')
+    })
+
+    it('アルバムが存在すること', () => {
+      expect(wrapper.find('div[class="album"]').exists()).toBe(true)
+    })
+
+    it('カードが存在すること', () => {
+      expect(wrapper.find('div[class="card"]').exists()).toBe(true)
+      expect(wrapper.find('img').exists()).toBe(true)
+      expect(wrapper.find('div[class="card-body"]').exists()).toBe(true)
+      expect(wrapper.find('h5').attributes('class')).toContain('card-title')
+      expect(wrapper.find('p[class="card-text"]').exists()).toBe(true)
+      expect(wrapper.find('a').text()).toBe('詳細へ')
+    })
+
+    it('外部リンクが存在すること', () => {
+      expect(wrapper.findComponent({ ref: 'linkHome' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
+    })
+  })
+})

--- a/frontend/test/component/search_results/SearchResultsListView.test.js
+++ b/frontend/test/component/search_results/SearchResultsListView.test.js
@@ -1,22 +1,41 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import SearchResultsListView from '@/components/search_results/SearchResultsListView.vue'
-// import { RouterLink } from 'vue-router'
+import axios from 'axios'
+
+vi.mock('axios')
 
 describe('SearchResultsListView', () => {
   let wrapper
 
-  beforeEach(() => {
-    wrapper = mount(SearchResultsListView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
-        }
-      }
-    })
-  })
-
   describe('DOMの構造', () => {
+    beforeEach(async () => {
+      axios.get
+        .mockResolvedValueOnce({
+          data: [
+            { "id": 1 }
+          ]      
+        })
+  
+        .mockResolvedValueOnce({
+          data: {
+            "id": 1,
+            "name": "無電解ニッケルめっき",
+            "image_url": "http://localhost:3000/electroless_nickel_plating.jpeg"
+          }
+        })
+  
+      wrapper = mount(SearchResultsListView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+  
+      await flushPromises()
+    })
+
     it('見出しが存在すること', () => {
       expect(wrapper.find('h3').exists()).toBe(true)
       expect(wrapper.find('h3').text()).toBe('表面処理一覧')
@@ -32,13 +51,87 @@ describe('SearchResultsListView', () => {
       expect(wrapper.find('div[class="card-body"]').exists()).toBe(true)
       expect(wrapper.find('h5').attributes('class')).toContain('card-title')
       expect(wrapper.find('p[class="card-text"]').exists()).toBe(true)
-      expect(wrapper.find('a').text()).toBe('詳細へ')
+      expect(wrapper.findComponent({ ref: 'linkSample1' }).text()).toBe('詳細へ')
+      expect(wrapper.findComponent({ ref: 'linkSample1' }).props().to).toBe('/samples/1')
     })
 
     it('外部リンクが存在すること', () => {
       expect(wrapper.findComponent({ ref: 'linkHome' }).exists()).toBe(true)
       expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
       expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
+    })
+  })
+
+  describe('API通信', () => {
+    beforeEach(async () => {
+      axios.get
+        .mockResolvedValueOnce({
+          data: [
+            { id: 1 },
+            { id: 2 },
+            { id: 3 },
+            { id: 4 },
+            { id: 5 }
+          ]
+        })
+
+        .mockResolvedValueOnce({
+          data: {
+            "id": 1,
+            "name": "無電解ニッケルめっき",
+            "image_url": "http://localhost:3000/electroless_nickel_plating.jpeg"
+          }
+        })
+
+        .mockResolvedValueOnce({
+          data: {
+            "id": 2,
+            "name": "白金めっき",
+            "image_url": "http://localhost:3000/white_silver_plating.jpeg"
+          }
+        })
+
+        .mockResolvedValueOnce({
+          data: {
+            "id": 3,
+            "name": "金めっき",
+            "image_url": "http://localhost:3000/gold_plate.jpeg"
+          }
+        })
+
+        .mockResolvedValueOnce({
+          data: {
+            "id": 4,
+            "name": "銀めっき",
+            "image_url": "http://localhost:3000/silver_plating.jpeg"
+          }
+        })
+
+        .mockResolvedValueOnce({
+          data: {
+            "id": 5,
+            "name": "銅めっき",
+            "image_url": "http://localhost:3000/copper_plating.jpeg"
+          }
+        })
+        
+      wrapper = mount(SearchResultsListView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
+    it('取得したデータの件数分だけサンプルのリンクが表示されること', () => {
+      expect(wrapper.findComponent({ ref: 'linkSample1' }).props().to).toBe('/samples/1')
+      expect(wrapper.findComponent({ ref: 'linkSample2' }).props().to).toBe('/samples/2')
+      expect(wrapper.findComponent({ ref: 'linkSample3' }).props().to).toBe('/samples/3')
+      expect(wrapper.findComponent({ ref: 'linkSample4' }).props().to).toBe('/samples/4')
+      expect(wrapper.findComponent({ ref: 'linkSample5' }).props().to).toBe('/samples/5')
     })
   })
 })

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -177,7 +177,9 @@ describe('Static Pages routing', () => {
 
     expect(wrapper.html()).toContain('メーカー名で検索')
   })
+})
 
+describe('Search Results routing', () => {
   describe('パラメータにnameを指定した場合', () => {
     it('nameを含むパスの「表面処理の検索結果」ページに遷移すること', async () => {
       router.push({
@@ -245,5 +247,21 @@ describe('Static Pages routing', () => {
       expect(wrapper.html()).toContain('表面処理の検索結果')
       expect(wrapper.findComponent('#link_research').props().to).toBe('/static_pages/maker')
     })
+  })
+
+  it('「表面処理一覧」ページに遷移すること', async () => {
+    router.push('/list_search_results')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router]
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('表面処理一覧')    
   })
 })


### PR DESCRIPTION
## 概要
Rails ビューを Vue.js でリファインする。
コンポーネント名：SearchResultsListView.vue
テスト名：SearchResultsListView.test.js

## 実装
- backend
  - [x] コントローラ
  - [x] ルーティング
  - [x] curl でレスポンスを確認
  - [x] テスト
- frontend
  - [x] コンポーネント
  - [x] ルーティング
  - [x] テスト
  - [x] リクエスト・レスポンス
  - [x] テスト
  - [x] コードスタイルや UI/UX の微調整