### PR TITLE
Categories コンポーネントの例外処理と正常・異常時のメッセージを実装

### DIFF
--- a/frontend/src/components/categories/CategoriesEditView.vue
+++ b/frontend/src/components/categories/CategoriesEditView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from 'axios'
 
+const emit = defineEmits(['message'])
 const route = useRoute()
 const router = useRouter()
 const category = ref({ item: '', summary: '' })
@@ -14,7 +15,10 @@ const fetchCategoryData = async (id) => {
     const response = await axios.get(`${API_BASE_URL}/categories/${id}`)
     category.value = response.data
   } catch (error) {
-    console.error('Get category data failed')
+    if (error.response && error.response.status === 404) {
+      emit('message', { type: 'danger', text: 'カテゴリー情報の取得に失敗しました。' })
+      router.replace({ name: 'NotFound' })
+    }
   }
 }
 
@@ -25,6 +29,7 @@ const categoryUpdate = async () => {
       summary: category.value.summary
     })
     category.value = response.data
+    emit('message', { type: 'success', text: 'カテゴリー情報を更新しました。' })
     router.push(`/categories/${category.value.id}`)
   } catch (error) {
     errorMessage.value = '入力に不備があります。'

--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import axios from 'axios'
+import router from '@/router'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const emit = defineEmits(['message'])
 const categories = ref([])
 
 function replaceStringWithEllipsis() {
@@ -19,7 +21,10 @@ const fetchCategoryList = async () => {
     categories.value = response.data
     replaceStringWithEllipsis()
   } catch (error) {
-    console.error('Get category list failed')
+    if (error.response && error.response.status === 404) {
+      emit('message', { type: 'danger', text: 'カテゴリーの取得に失敗しました。' })
+      router.replace({ name: 'NotFound' })
+    }
   }
 }
 

--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -45,7 +45,12 @@ onMounted(() => {
         </div>
       </div>
 
-      <RouterLink v-for="category in categories" v-bind:key="category.id" class="list-group-item list-group-item-action" v-bind:to="`/categories/${category.id}`">
+      <RouterLink
+        v-for="category in categories"
+        v-bind:key="category.id"
+        class="list-group-item list-group-item-action"
+        v-bind:to="`/categories/${category.id}`"
+      >
         <div class="d-flex w-100 justify-content-between">
           <h6>{{ category.item }}</h6>
           <h6>{{ category.summary }}</h6>

--- a/frontend/src/components/categories/CategoriesNewView.vue
+++ b/frontend/src/components/categories/CategoriesNewView.vue
@@ -3,6 +3,7 @@
   import axios from 'axios'
   import router from '@/router'
 
+  const emit = defineEmits(['message'])
   const item = ref('')
   const summary = ref('')
   const category = ref('')
@@ -18,6 +19,7 @@
         }
       })
       category.value = response.data
+      emit('message', { type: 'success', text: 'カテゴリーを1件登録しました。' })
       router.push(`/categories/${category.value.id}`)
     } catch (error) {
       errorMessage.value = '入力に不備があります。'

--- a/frontend/src/components/categories/CategoriesShowView.vue
+++ b/frontend/src/components/categories/CategoriesShowView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from 'axios'
 
+const emit = defineEmits(['message'])
 const category = ref({ data: { item: '', summary: '' } })
 const route = useRoute()
 const router = useRouter()
@@ -14,7 +15,10 @@ const fetchCategoryData = async (id) => {
     const response = await axios.get(`${API_BASE_URL}/categories/${id}`)
     category.value = response.data
   } catch (error) {
-    console.error('Get category information failed')
+    if (error.response && error.response.status === 404) {
+      emit('message', { type: 'danger', text: 'カテゴリーの取得に失敗しました。' })
+      router.replace({ name: 'NotFound' })
+    }
   }
 }
 
@@ -24,9 +28,13 @@ const handleDelete = async () => {
 
   try {
     await axios.delete(`${API_BASE_URL}/categories/${route.params.id}`)
+    emit('message', { type: 'success', text: 'カテゴリーを1件削除しました。' })
     router.push('/categories')
   } catch (error) {
-    console.error('削除処理に失敗しました', error)
+    if (error.response && error.response.status === 404) {
+      emit('message', { type: 'danger', text: '削除処理に失敗しました。' })
+      router.replace({ name: 'NotFound' })
+    }
   }
 }
 

--- a/frontend/test/component/categories/CategoriesIndexView.test.js
+++ b/frontend/test/component/categories/CategoriesIndexView.test.js
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import CategoriesIndexView from '@/components/categories/CategoriesIndexView.vue'
+import axios from 'axios'
+import router from '@/router'
+
+vi.mock('axios')
 
 describe('CategoriesIndexView', () => {
   describe('コンポーネントのレンダリング', () => {
@@ -48,6 +52,66 @@ describe('CategoriesIndexView', () => {
 
       expect(link).toBeDefined()
       expect(link.props().to).toBe('/home')
+    })
+  })
+
+  describe('API通信', () => {
+    describe('カテゴリーリストの取得に成功した場合', () => {
+      it('カテゴリーの一覧が表示されること', async () => {
+        axios.get.mockResolvedValue({
+          data: [
+            { "id": 1, "item": "めっき" },
+            { "id": 2, "item": "陽極酸化" },
+            { "id": 3, "item": "化成" },
+            { "id": 4, "item": "コーティング" },
+            { "id": 5, "item": "表面硬化" }
+          ]
+        })
+
+        const wrapper = mount(CategoriesIndexView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
+
+        await flushPromises()
+
+        expect(wrapper.text()).toContain('めっき')
+        expect(wrapper.text()).toContain('陽極酸化')
+        expect(wrapper.text()).toContain('化成')
+        expect(wrapper.text()).toContain('コーティング')
+        expect(wrapper.text()).toContain('表面硬化')
+      })
+    })
+
+    describe('カテゴリーリストの取得に失敗した場合', () => {
+      it('404ページに遷移すること', async () => {
+        axios.get.mockRejectedValue({
+          response: {
+            status: 404
+          }
+        })
+
+        router.replace = vi.fn()
+
+        const wrapper = mount(CategoriesIndexView, {
+          global: {
+            stubs: {
+              RouterLink: RouterLinkStub
+            }
+          }
+        })
+
+        await flushPromises()
+
+        expect(wrapper.emitted()).toHaveProperty('message')
+        expect(wrapper.emitted().message[0]).toEqual([
+          { type: 'danger', text: 'カテゴリーの取得に失敗しました。' }
+        ])
+        expect(router.replace).toHaveBeenCalledWith({ name: 'NotFound' })
+      })
     })
   })
 })

--- a/frontend/test/component/categories/CategoriesNewView.test.js
+++ b/frontend/test/component/categories/CategoriesNewView.test.js
@@ -54,6 +54,7 @@ describe('カテゴリー登録で', () => {
     it('登録が成功すること', async () => {
       const mockCategory = {
         data: {
+          id: 1,
           item: 'test item',
           summary: 'test summary'
         }
@@ -68,6 +69,10 @@ describe('カテゴリー登録で', () => {
       await summaryTextArea.setValue('test summary')
       await wrapper.find('form').trigger('submit.prevent')
 
+      expect(wrapper.emitted()).toHaveProperty('message')
+      expect(wrapper.emitted().message[0]).toEqual([
+        { type: 'success', text: 'カテゴリーを1件登録しました。' }
+      ])
       expect(router.push).toHaveBeenCalledWith(`/categories/${mockCategory.id}`)
     })
   })


### PR DESCRIPTION
## 作業内容
- Index
  - [x] fetchCategoryList 例外処理と異常時のメッセージ
  - [x] API通信のテスト追加
- Show
  - [x] fetchCategoryData 例外処理と異常時のメッセージ
  - [x] handleDelete 例外処理と正常・異常時のメッセージ
- New
  - [x] categoryRegistration 正常時のメッセージ
- Edit
  - [x] fetchCategoryData 例外処理と異常時のメッセージ
  - [x] categoryUpdate 正常時のメッセージ
- コードスタイルの微調整
  - [x] index の RouterLink を改行

## 参考にするコード
#### component
```javascript
if (error.response && error.response.status === 404) {
  emit('message', { type: 'danger', text: 'カテゴリーの取得に失敗しました。' })
  router.replace({ name: 'NotFound' })
}
```
#### test
```javascript
expect(wrapper.emitted()).toHaveProperty('message')
expect(wrapper.emitted().message[0]).toEqual([
  { type: 'danger', text: '削除処理に失敗しました。' }
])
expect(router.replace).toHaveBeenCalledWith({ name: 'NotFound' })
```