### PR TITLE
各コントローラのアクションにHTTPステータスを明示する

### DIFF
--- a/backend/app/controllers/categories_controller.rb
+++ b/backend/app/controllers/categories_controller.rb
@@ -2,13 +2,13 @@ class CategoriesController < ApplicationController
   def index
     categories = Category.all
 
-    render json: categories
+    render json: categories, status: :ok
   end
 
   def show
     category = Category.find(params[:id])
 
-    render json: category
+    render json: category, status: :ok
   end
 
   def create
@@ -25,7 +25,7 @@ class CategoriesController < ApplicationController
     category = Category.find(params[:id])
 
     if category.update(category_params)
-      render json: category
+      render json: category, status: :ok
     else
       render json: category.errors, status: :unprocessable_entity
     end
@@ -34,6 +34,7 @@ class CategoriesController < ApplicationController
   def destroy
     category = Category.find(params[:id])
     category.destroy
+    head :no_content
   end
 
   private

--- a/backend/app/controllers/comments_controller.rb
+++ b/backend/app/controllers/comments_controller.rb
@@ -3,14 +3,14 @@ class CommentsController < ApplicationController
     sample = Sample.find(params[:sample_id])
     comments = sample.comments
 
-    render json: comments
+    render json: comments, status: :ok
   end
 
   def show
     sample = Sample.find(params[:sample_id])
     comment = sample.comments.find(params[:id])
 
-    render json: comment
+    render json: comment, status: :ok
   end
 
   def create
@@ -29,7 +29,7 @@ class CommentsController < ApplicationController
     comment = sample.comments.find(params[:id])
 
     if comment.update(comment_params)
-      render json: comment
+      render json: comment, status: :ok
     else
       render json: comment.errors, status: :unprocessable_entity
     end
@@ -39,6 +39,7 @@ class CommentsController < ApplicationController
     sample = Sample.find(params[:sample_id])
     comment = sample.comments.find(params[:id])
     comment.destroy
+    head :no_content
   end
 
   private

--- a/backend/app/controllers/home_controller.rb
+++ b/backend/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
   def index
-    render json: { message: "API Root" }
+    render json: { message: "API Root" }, status: :ok
   end
 end

--- a/backend/app/controllers/makers_controller.rb
+++ b/backend/app/controllers/makers_controller.rb
@@ -3,14 +3,17 @@ class MakersController < ApplicationController
     makers = Maker.paginate(page: params[:page], per_page: 7)
 
     render json: {
-      makers: makers, current_page: makers.current_page, total_pages: makers.total_pages
-    }
+      makers: makers,
+      current_page: makers.current_page,
+      total_pages: makers.total_pages
+    },
+    status: :ok
   end
 
   def show
     maker = Maker.find(params[:id])
 
-    render json: maker
+    render json: maker, status: :ok
   end
 
   def create
@@ -27,7 +30,7 @@ class MakersController < ApplicationController
     maker = Maker.find(params[:id])
 
     if maker.update(maker_params)
-      render json: maker
+      render json: maker, status: :ok
     else
       render json: maker.errors, status: :unprocessable_entity
     end
@@ -36,6 +39,7 @@ class MakersController < ApplicationController
   def destroy
     maker = Maker.find(params[:id])
     maker.destroy
+    head :no_content
   end
 
   private

--- a/backend/app/controllers/samples_controller.rb
+++ b/backend/app/controllers/samples_controller.rb
@@ -6,13 +6,14 @@ class SamplesController < ApplicationController
       samples: samples,
       current_page: samples.current_page,
       total_pages: samples.total_pages
-    }
+    },
+    status: :ok
   end
 
   def show
     sample = Sample.find(params[:id])
 
-    render json: sample, methods: [:image_url]
+    render json: sample, status: :ok, methods: [:image_url]
   end
 
   def create
@@ -29,7 +30,7 @@ class SamplesController < ApplicationController
     sample = Sample.find(params[:id])
 
     if sample.update(sample_params)
-      render json: sample
+      render json: sample, status: :ok
     else
       render json: sample.errors, status: :unprocessable_entity
     end
@@ -38,7 +39,6 @@ class SamplesController < ApplicationController
   def destroy
     sample = Sample.find(params[:id])
     sample.destroy
-    
     head :no_content
   end
 

--- a/backend/app/controllers/searches_controller.rb
+++ b/backend/app/controllers/searches_controller.rb
@@ -6,7 +6,8 @@ class SearchesController < ApplicationController
     render json: {
       samples: samples,
       keyword: keyword
-    }
+    },
+    status: :ok
   end
 
   def category_search
@@ -16,7 +17,8 @@ class SearchesController < ApplicationController
     render json: {
       samples: samples,
       keyword: keyword
-    }
+    },
+    status: :ok
   end
 
   def maker_search
@@ -26,12 +28,13 @@ class SearchesController < ApplicationController
     render json: {
       samples: samples,
       keyword: keyword
-    }
+    },
+    status: :ok
   end
 
   def list_search
     samples = Sample.order(:id)
 
-    render json: samples
+    render json: samples, status: :ok
   end
 end

--- a/backend/app/controllers/sessions_controller.rb
+++ b/backend/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
 
     if user && user.authenticate(params[:password])
       session[:user_id] = user.id
-      render json: { logged_in: true, user: user }
+      render json: { logged_in: true, user: user }, status: :ok
     else
       render json: { logged_in: false, error: 'Invalid name or password' }, status: :unprocessable_entity
     end
@@ -12,15 +12,15 @@ class SessionsController < ApplicationController
 
   def destroy
     session[:user_id] = nil
-    render json: { logged_in: false }
+    render json: { logged_in: false }, status: :ok
   end
 
   def logged_in?
     if session[:user_id]
       user = User.find(session[:user_id])
-      render json: { logged_in: true, user: user }
+      render json: { logged_in: true, user: user }, status: :ok
     else
-      render json: { logged_in: false }
-    end  
+      render json: { logged_in: false }, status: :ok
+    end
   end
 end

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -4,13 +4,14 @@ class UsersController < ApplicationController
 
     render json: {
       users: users, current_page: users.current_page, total_pages: users.total_pages
-    }
+    },
+    status: :ok
   end
 
   def show
     user = User.find(params[:id])
 
-    render json: user
+    render json: user, status: :ok
   end
 
   def create
@@ -27,7 +28,7 @@ class UsersController < ApplicationController
     user = User.find(params[:id])
 
     if user.update(user_params)
-      render json: user
+      render json: user, status: :ok
     else
       render json: user.errors, status: :unprocessable_entity
     end
@@ -36,6 +37,7 @@ class UsersController < ApplicationController
   def destroy
     user = User.find(params[:id])
     user.destroy
+    head :no_content
   end
 
   private

--- a/backend/spec/requests/categories_spec.rb
+++ b/backend/spec/requests/categories_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe "Categories API", type: :request do
       expect(response).to have_http_status(:no_content)
     end
 
+    it 'レスポンスの本文が空であること' do
+      delete "/categories/#{@category.id}"
+      expect(response.body).to be_blank
+    end
+
     it 'カテゴリーの削除に成功すること' do
       expect { delete "/categories/#{@category.id}" }.to change{ Category.count }.from(1).to(0)
     end

--- a/backend/spec/requests/categories_spec.rb
+++ b/backend/spec/requests/categories_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Categories API", type: :request do
       @category = FactoryBot.create(:category)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/categories"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'カテゴリーリストが1件返ること' do
@@ -23,9 +23,9 @@ RSpec.describe "Categories API", type: :request do
       @category = FactoryBot.create(:category)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/categories/#{@category.id}"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'カテゴリー情報が返ること' do
@@ -82,6 +82,11 @@ RSpec.describe "Categories API", type: :request do
     end
 
     context '有効なカテゴリー情報で更新したとき' do
+      it 'レスポンスのステータスがokであること' do
+        patch "/categories/#{@category.id}", params: { category: { item: 'sample category' } }
+        expect(response).to have_http_status(:ok)
+      end
+
       it 'itemがsample categoryで更新されること' do
         patch "/categories/#{@category.id}", params: { category: { item: 'sample category' } }
         json = JSON.parse(response.body, symbolize_names: true)
@@ -106,6 +111,11 @@ RSpec.describe "Categories API", type: :request do
   describe '#destroy' do
     before do
       @category = FactoryBot.create(:category)
+    end
+
+    it 'レスポンスのステータスがno_contentであること' do
+      delete "/categories/#{@category.id}"
+      expect(response).to have_http_status(:no_content)
     end
 
     it 'カテゴリーの削除に成功すること' do

--- a/backend/spec/requests/comments_spec.rb
+++ b/backend/spec/requests/comments_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Comments API", type: :request do
       @comment = Comment.first
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/samples/#{@comment.sample_id}/comments"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'コメントの件数が10件返ること' do
@@ -26,9 +26,9 @@ RSpec.describe "Comments API", type: :request do
       @comment = FactoryBot.create(:comment)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/samples/#{@comment.sample_id}/comments/#{@comment.id}"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'コメントの詳細が返ること' do
@@ -93,6 +93,11 @@ RSpec.describe "Comments API", type: :request do
     end
 
     context '有効なコメント情報で更新したとき' do
+      it 'レスポンスのステータスがokであること' do
+        patch "/samples/#{@comment.sample_id}/comments/#{@comment.id}",params: { comment: { commenter: 'sample user' } }
+        expect(response).to have_http_status(:ok)
+      end
+
       it 'commenterがsample userで更新されること' do
         patch "/samples/#{@comment.sample_id}/comments/#{@comment.id}",params: { comment: { commenter: 'sample user' } }
         json = JSON.parse(response.body, symbolize_names: true)
@@ -118,6 +123,16 @@ RSpec.describe "Comments API", type: :request do
     before do
       FactoryBot.create(:sample)
       @comment = FactoryBot.create(:comment)
+    end
+
+    it 'レスポンスのステータスがno_contentであること' do
+      delete "/samples/#{@comment.sample_id}/comments/#{@comment.id}"
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'レスポンスのbodyが空であること' do
+      delete "/samples/#{@comment.sample_id}/comments/#{@comment.id}"
+      expect(response.body).to be_blank
     end
 
     it 'コメントが1件削除されること' do

--- a/backend/spec/requests/home_spec.rb
+++ b/backend/spec/requests/home_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Home", type: :request do
   describe "#index" do
-    it "レスポンスのステータスがsuccessであること" do
+    it "レスポンスのステータスがokであること" do
       get "/"
       expect(response).to have_http_status(:ok)
     end

--- a/backend/spec/requests/home_spec.rb
+++ b/backend/spec/requests/home_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Home", type: :request do
   describe "#index" do
     it "レスポンスのステータスがsuccessであること" do
       get "/"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/backend/spec/requests/makers_spec.rb
+++ b/backend/spec/requests/makers_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Makers API", type: :request do
       FactoryBot.create_list(:maker_list, 7)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/makers"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスのmakersは7件であること' do
@@ -35,9 +35,9 @@ RSpec.describe "Makers API", type: :request do
       @maker = FactoryBot.create(:maker)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/makers/#{@maker.id}"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'メーカー情報が返ること' do
@@ -105,6 +105,11 @@ RSpec.describe "Makers API", type: :request do
     end
 
     context '有効なメーカー情報で更新したとき' do
+      it 'レスポンスのステータスがokであること' do
+        patch "/makers/#{@maker.id}", params: { maker: { name: 'sample maker' } }
+        expect(response).to have_http_status(:ok)
+      end
+
       it 'nameがsample makerで更新されること' do
         patch "/makers/#{@maker.id}", params: { maker: { name: 'sample maker' } }
         json = JSON.parse(response.body, symbolize_names: true)
@@ -129,6 +134,16 @@ RSpec.describe "Makers API", type: :request do
   describe '#destroy' do
     before do
       @maker = FactoryBot.create(:maker)
+    end
+
+    it 'レスポンスのステータスがno_contentであること' do
+      delete "/makers/#{@maker.id}"
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'レスポンスの本文が空であること' do
+      delete "/makers/#{@maker.id}"
+      expect(response.body).to be_blank
     end
 
     it 'メーカーの削除に成功すること' do

--- a/backend/spec/requests/samples_spec.rb
+++ b/backend/spec/requests/samples_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Samples API", type: :request do
       FactoryBot.create_list(:sample_list, 10)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/samples"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスにsamplesが含まれていること' do
@@ -42,9 +42,9 @@ RSpec.describe "Samples API", type: :request do
       FileUtils.rm_rf(ActiveStorage::Blob.service.root)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/samples/#{@sample.id}" 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスに主要な属性がすべて含まれていること' do
@@ -140,6 +140,11 @@ RSpec.describe "Samples API", type: :request do
     end
 
     context '有効な表面処理情報で更新したとき' do
+      it 'レスポンスのステータスがokであること' do
+        patch "/samples/#{@sample.id}", params: { sample: { name: "ハードクロムめっき" } }
+        expect(response).to have_http_status(:ok)
+      end
+
       it 'nameがハードクロムめっきで更新されること' do
         patch "/samples/#{@sample.id}", params: { sample: { name: "ハードクロムめっき" } }
         json = JSON.parse(response.body, symbolize_names: true)
@@ -172,6 +177,11 @@ RSpec.describe "Samples API", type: :request do
     it 'レスポンスのステータスがno_contentであること' do
       delete "/samples/#{@sample.id}"      
       expect(response).to have_http_status(:no_content)
+    end
+
+    it 'レスポンスの本文が空であること' do
+      delete "/samples/#{@sample.id}"      
+      expect(response.body).to be_blank
     end
     
     it '表面処理の削除に成功すること' do

--- a/backend/spec/requests/searches_spec.rb
+++ b/backend/spec/requests/searches_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Searches", type: :request do
   end
 
   describe '#name_search' do
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get '/name_search'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスのjsonに:samplesと:keywordが含まれていること' do
@@ -22,9 +22,9 @@ RSpec.describe "Searches", type: :request do
   end
 
   describe '#category_search' do
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get '/category_search'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスのjsonに:samplesと:keywordが含まれていること' do
@@ -39,9 +39,9 @@ RSpec.describe "Searches", type: :request do
   end
 
   describe '#maker_search' do
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get '/maker_search'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスのjsonに:samplesと:keywordが含まれていること' do
@@ -56,9 +56,9 @@ RSpec.describe "Searches", type: :request do
   end
 
   describe '#list_search' do
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get '/list_search'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスのjsonにサンプルが5件含まれていること' do

--- a/backend/spec/requests/sessions_spec.rb
+++ b/backend/spec/requests/sessions_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe "Sessions", type: :request do
         @valid_login_params = { name: 'general user', password: 'generalpassword' }
       end
 
-      it 'ステータスコードのレスポンスがsuccessであること' do
+      it 'ステータスコードのレスポンスがokであること' do
         post "/login", params: @valid_login_params
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:ok)
       end
 
       it 'セッションにgeneral userのidが登録されること' do
@@ -52,9 +52,15 @@ RSpec.describe "Sessions", type: :request do
       post "/login", params: { name: user.name, password: user.password }
     end
 
-    it 'レスポンスのステータスコードがsuccessであること' do
+    it 'レスポンスのステータスコードがokであること' do
       delete "/logout"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'ログイン状態がfalseであること' do
+      delete "/logout"
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json[:logged_in]).to eq(false)
     end
 
     it 'セッションのユーザーidが空であること' do
@@ -82,9 +88,9 @@ RSpec.describe "Sessions", type: :request do
         expect(json[:user][:id]).to eq(@user.id)
       end
 
-      it 'レスポンスのステータスコードがsuccessであること' do
+      it 'レスポンスのステータスコードがokであること' do
         get "/logged_in?"
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -95,9 +101,9 @@ RSpec.describe "Sessions", type: :request do
         expect(json[:logged_in]).to eq(false)
       end
 
-      it 'レスポンスのステータスがsuccessであること' do
+      it 'レスポンスのステータスがokであること' do
         get "/logged_in?"
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/backend/spec/requests/users_spec.rb
+++ b/backend/spec/requests/users_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Users API", type: :request do
       FactoryBot.create_list(:user_list, 10)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/users.json"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'レスポンスのusersは10件であること' do
@@ -35,9 +35,9 @@ RSpec.describe "Users API", type: :request do
       @user = FactoryBot.create(:user)
     end
 
-    it 'レスポンスのステータスがsuccessであること' do
+    it 'レスポンスのステータスがokであること' do
       get "/users/#{@user.id}.json"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'json形式のユーザー情報が返ること' do
@@ -98,6 +98,11 @@ RSpec.describe "Users API", type: :request do
     end
 
     context '有効なユーザー情報で更新したとき' do
+      it 'レスポンスのステータスがokであること' do
+        patch "/users/#{@user.id}", params: { user: { name: 'sample user' } }
+        expect(response).to have_http_status(:ok)
+      end
+
       it 'nameがsample userで更新されること' do
         patch "/users/#{@user.id}", params: { user: { name: 'sample user' } }
         json = JSON.parse(response.body, symbolize_names: true)
@@ -122,6 +127,11 @@ RSpec.describe "Users API", type: :request do
   describe '#destroy' do
     before do
       @user = FactoryBot.create(:sample_user)
+    end
+
+    it 'レスポンスのステータスがno_contentであること' do
+      delete "/users/#{@user.id}"
+      expect(response).to have_http_status(:no_content)
     end
 
     it 'ユーザーの削除に成功すること' do

--- a/backend/spec/requests/users_spec.rb
+++ b/backend/spec/requests/users_spec.rb
@@ -134,6 +134,11 @@ RSpec.describe "Users API", type: :request do
       expect(response).to have_http_status(:no_content)
     end
 
+    it 'レスポンスの本文が空であること' do
+      delete "/users/#{@user.id}"
+      expect(response.body).to be_blank
+    end
+
     it 'ユーザーの削除に成功すること' do
       expect { delete "/users/#{@user.id}" }.to change{ User.count }.from(1).to(0)
     end


### PR DESCRIPTION
## タスク
- [x] Rails でよく使用するステータスコードの種類と内容を調査
- [x] 各コントローラの修正
  - [x] categories
  - [x] comments
  - [x] home
  - [x] makers
  - [x] samples
  - [x] searches
  - [x] sessions
  - [x] users

#### 追加タスク
- [x] categories_spec.rb に レスポンスの本文が空の検証を追加
- [x] home_spec.rb の success を ok に変更