### PR TITLE
RouterLinkに ref を定義する

### DIFF
--- a/frontend/src/components/HomeView.vue
+++ b/frontend/src/components/HomeView.vue
@@ -21,7 +21,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">処理名で検索</h5>
             <p class="card-text">処理名を入力して表面処理を検索します。</p>
-            <RouterLink to="/static_pages/name" class="card-link">検索ページへ</RouterLink>
+            <RouterLink to="/static_pages/name" class="card-link" ref="linkSearchName">検索ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -31,7 +31,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">カテゴリーで検索</h5>
             <p class="card-text">カテゴリーを選択して表面処理を検索します。</p>
-            <RouterLink to="/static_pages/category" class="card-link">検索ページへ</RouterLink>
+            <RouterLink to="/static_pages/category" class="card-link" ref="linkSearchCategory">検索ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -41,7 +41,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">メーカー名で検索</h5>
             <p class="card-text">メーカー名を入力して表面処理を検索します。</p>
-            <RouterLink to="/static_pages/maker" class="card-link">検索ページへ</RouterLink>
+            <RouterLink to="/static_pages/maker" class="card-link" ref="linkSearchMaker">検索ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -51,7 +51,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">処理一覧から検索</h5>
             <p class="card-text">表面処理一覧から目的の処理を検索します。</p>
-            <RouterLink to="/list_search_results" class="card-link">検索ページへ</RouterLink>
+            <RouterLink to="/list_search_results" class="card-link" ref="linkSearchList">検索ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -64,7 +64,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">表面処理の管理</h5>
             <p class="card-text">表面処理に関する情報を一括管理します。</p>
-            <RouterLink to="/samples" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/samples" class="card-link" ref="linkManageSamples">管理ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -74,7 +74,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">カテゴリーの管理</h5>
             <p class="card-text">カテゴリーに関する情報を一括管理します。</p>
-            <RouterLink to="/categories" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/categories" class="card-link" ref="linkManageCategories">管理ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -84,7 +84,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">メーカーの管理</h5>
             <p class="card-text">メーカーに関する情報を一括管理します。</p>
-            <RouterLink to="/makers" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/makers" class="card-link" ref="linkManageMakers">管理ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -94,7 +94,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">ユーザーの管理</h5>
             <p class="card-text">ユーザーに関する情報を一括管理します。</p>
-            <RouterLink to="/users" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/users" class="card-link" ref="linkManageUsers">管理ページへ</RouterLink>
           </div>
         </div>
       </div>
@@ -107,7 +107,7 @@ import settingsIcon from '@/assets/icons/settings.svg'
           <div class="card-body">
             <h5 class="card-title">アプリケーションの管理</h5>
             <p class="card-text">アプリケーションの設定やログアウトを行います。</p>
-            <RouterLink to="/settings" class="card-link">管理ページへ</RouterLink>
+            <RouterLink to="/settings" class="card-link" ref="linkSettings">管理ページへ</RouterLink>
           </div>
         </div>
       </div>

--- a/frontend/src/components/UsersEditView.vue
+++ b/frontend/src/components/UsersEditView.vue
@@ -93,8 +93,8 @@ onMounted(() => {
     <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
     
     <div class="d-flex justify-content-evenly">
-      <RouterLink v-bind:to="`/users/${user.id}`" id="user_information">ユーザー情報</RouterLink>
-      <RouterLink to="/users" id="user_list">ユーザーリスト</RouterLink>
+      <RouterLink v-bind:to="`/users/${user.id}`" ref="linkUsersShow">ユーザー情報</RouterLink>
+      <RouterLink to="/users" ref="linkUsers">ユーザーリスト</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/UsersIndexView.vue
+++ b/frontend/src/components/UsersIndexView.vue
@@ -78,8 +78,8 @@ onMounted(() => {
     </ul>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink to="/users/new">ユーザー情報の登録</RouterLink>
-      <RouterLink to="/home">メインメニューへ</RouterLink>
+      <RouterLink to="/users/new" ref="linkUsersNew">ユーザー情報の登録</RouterLink>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/UsersNewView.vue
+++ b/frontend/src/components/UsersNewView.vue
@@ -66,6 +66,6 @@ const userRegistration = async () => {
     </form>
     <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
     
-    <RouterLink to="/users" class="d-flex justify-content-evenly">ユーザーリスト</RouterLink>
+    <RouterLink to="/users" class="d-flex justify-content-evenly" ref="linkUsersNew">ユーザーリスト</RouterLink>
   </div>
 </template>

--- a/frontend/src/components/UsersShowView.vue
+++ b/frontend/src/components/UsersShowView.vue
@@ -58,8 +58,8 @@ onMounted(() => {
     </div>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink v-bind:to="`/users/${user.id}/edit`">ユーザー情報の編集</RouterLink>
-      <RouterLink to="/users">ユーザーリスト</RouterLink>
+      <RouterLink v-bind:to="`/users/${user.id}/edit`" ref="linkUsersEdit">ユーザー情報の編集</RouterLink>
+      <RouterLink to="/users" ref="linkUsers">ユーザーリスト</RouterLink>
       <p v-on:click="handleDelete" class="text-primary text-decoration-underline">
         ユーザーの削除
       </p>

--- a/frontend/src/components/categories/CategoriesEditView.vue
+++ b/frontend/src/components/categories/CategoriesEditView.vue
@@ -58,8 +58,8 @@ onMounted(() => {
     <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink v-bind:to="`/categories/${category.id}`">カテゴリー情報へ</RouterLink>
-      <RouterLink to="/categories">カテゴリーリストへ</RouterLink>
+      <RouterLink v-bind:to="`/categories/${category.id}`" ref="linkCategoriesShow">カテゴリー情報へ</RouterLink>
+      <RouterLink to="/categories" ref="linkCategories">カテゴリーリストへ</RouterLink>
     </div>
   </div>  
 </template>

--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -60,8 +60,8 @@ onMounted(() => {
     </div>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink to="/categories/new">カテゴリー情報の登録</RouterLink>
-      <RouterLink to="/home">メインメニューへ</RouterLink>
+      <RouterLink to="/categories/new" ref="linkCategoriesNew">カテゴリー情報の登録</RouterLink>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/categories/CategoriesNewView.vue
+++ b/frontend/src/components/categories/CategoriesNewView.vue
@@ -44,6 +44,6 @@ const categoryRegistration = async () => {
 
     <p v-if="errorMessage" class="alert alert-danger mt-4" role="alert">{{ errorMessage }}</p>
 
-    <RouterLink to="/categories" class="d-flex justify-content-evenly">カテゴリーリストへ</RouterLink>
+    <RouterLink to="/categories" class="d-flex justify-content-evenly" ref="linkCategories">カテゴリーリストへ</RouterLink>
   </div>
 </template>

--- a/frontend/src/components/categories/CategoriesShowView.vue
+++ b/frontend/src/components/categories/CategoriesShowView.vue
@@ -59,11 +59,11 @@ onMounted(() => {
     </ul>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink v-bind:to="`/categories/${category.id}/edit`">カテゴリー情報の編集</RouterLink>
+      <RouterLink v-bind:to="`/categories/${category.id}/edit`" ref="linkCategoriesEdit">カテゴリー情報の編集</RouterLink>
       <p v-on:click="handleDelete" class="text-primary text-decoration-underline">
         カテゴリーの削除
       </p>
-      <RouterLink to="/categories">カテゴリーリストへ</RouterLink>
+      <RouterLink to="/categories" ref="linkCategories">カテゴリーリストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/makers/MakersEditView.vue
+++ b/frontend/src/components/makers/MakersEditView.vue
@@ -82,8 +82,8 @@ onMounted(() => {
     </form>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink v-bind:to="`/makers/${maker.id}`" id="maker_information">メーカー情報へ</RouterLink>
-      <RouterLink to="/makers" id="maker_list">メーカーリストへ</RouterLink>
+      <RouterLink v-bind:to="`/makers/${maker.id}`" ref="linkMakersShow">メーカー情報へ</RouterLink>
+      <RouterLink to="/makers" ref="linkMakers">メーカーリストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/makers/MakersIndexView.vue
+++ b/frontend/src/components/makers/MakersIndexView.vue
@@ -87,8 +87,8 @@ onMounted(() => {
     </ul>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink to="/makers/new">メーカー情報の登録</RouterLink>
-      <RouterLink to="/home">メインメニューへ</RouterLink>
+      <RouterLink to="/makers/new" ref="linkMakersNew">メーカー情報の登録</RouterLink>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/makers/MakersNewView.vue
+++ b/frontend/src/components/makers/MakersNewView.vue
@@ -75,7 +75,7 @@ const makerRegistration = async () => {
     </form>
 
     <div class="d-flex justify-content-center">
-      <RouterLink to="/makers">メーカーリストへ</RouterLink>
+      <RouterLink to="/makers" ref="linkMakers">メーカーリストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/makers/MakersShowView.vue
+++ b/frontend/src/components/makers/MakersShowView.vue
@@ -93,11 +93,11 @@ onMounted(() => {
       </div>
 
       <div class="d-flex justify-content-evenly">
-        <RouterLink v-if="maker.id" v-bind:to="`/makers/${maker.id}/edit`" id="maker_edit">メーカー情報の編集へ</RouterLink>
+        <RouterLink v-if="maker.id" v-bind:to="`/makers/${maker.id}/edit`" ref="linkMakersEdit">メーカー情報の編集へ</RouterLink>
         <p v-on:click="handleDelete" class="text-primary text-decoration-underline" id="maker_destroy">
           メーカー情報の削除
         </p>
-        <RouterLink to="/makers" id="maker_list">メーカーリストへ</RouterLink>
+        <RouterLink to="/makers" ref="linkMakers">メーカーリストへ</RouterLink>
       </div>
     </div>
   </div>

--- a/frontend/src/components/samples/SamplesEditView.vue
+++ b/frontend/src/components/samples/SamplesEditView.vue
@@ -101,8 +101,8 @@ onMounted(() => {
     </form>
 
     <div class="d-flex justify-content-evenly mb-5">
-      <RouterLink v-bind:to="`/samples/${sample.id}`" id="sample_show">表面処理情報へ</RouterLink>
-      <RouterLink to="/samples" id="sample_list">表面処理リストへ</RouterLink>
+      <RouterLink v-bind:to="`/samples/${sample.id}`" ref="linkSamplesEdit">表面処理情報へ</RouterLink>
+      <RouterLink to="/samples" ref="linkSamples">表面処理リストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/samples/SamplesIndexView.vue
+++ b/frontend/src/components/samples/SamplesIndexView.vue
@@ -87,8 +87,8 @@ onMounted(() => {
     </ul>
 
     <div class="d-flex justify-content-evenly">
-      <RouterLink to="/samples/new" id="link_samples_new">表面処理情報の登録</RouterLink>
-      <RouterLink to="/home" id="link_home">メインメニューへ</RouterLink>
+      <RouterLink to="/samples/new" ref="linkSamplesNew">表面処理情報の登録</RouterLink>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/samples/SamplesNewView.vue
+++ b/frontend/src/components/samples/SamplesNewView.vue
@@ -110,7 +110,7 @@ const sampleRegistration = async () => {
     </form>
 
     <div class="text-center mb-5">
-      <RouterLink to="/samples">表面処理リストへ</RouterLink>
+      <RouterLink to="/samples" ref="linkSamples">表面処理リストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/samples/SamplesShowView.vue
+++ b/frontend/src/components/samples/SamplesShowView.vue
@@ -143,11 +143,11 @@ onMounted(() => {
     </div>
 
     <div class="d-flex justify-content-evenly mt-5 mb-5">
-      <RouterLink v-bind:to="`/samples/${sample.id}/edit`" id="link_sample_edit">表面処理情報の編集</RouterLink>
+      <RouterLink v-bind:to="`/samples/${sample.id}/edit`" ref="linkSamplesEdit">表面処理情報の編集</RouterLink>
       <p v-on:click="handleDelete" class="text-primary text-decoration-underline" id="link_sample_destroy">
         表面処理情報の削除
       </p>
-      <RouterLink to="/samples" id="link_samples">表面処理リストへ</RouterLink>
+      <RouterLink to="/samples" ref="linkSamples">表面処理リストへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/search_results/SearchResultsListView.vue
+++ b/frontend/src/components/search_results/SearchResultsListView.vue
@@ -63,7 +63,7 @@ onMounted(() => {
     </div>
 
     <div class="d-flex justify-content-evenly mt-5 mb-5">
-      <RouterLink to="/home" id="link_home" ref="linkHome">メインメニューへ</RouterLink>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/static_pages/StaticPagesCategoryView.vue
+++ b/frontend/src/components/static_pages/StaticPagesCategoryView.vue
@@ -29,7 +29,7 @@ const submitSearch = () => {
       <button type="submit" class="btn btn-secondary form-control mb-5">検索</button>
     </form>
     <div>
-      <RouterLink to="/home">メインメニューへ</RouterLink>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/src/components/static_pages/StaticPagesNameView.vue
+++ b/frontend/src/components/static_pages/StaticPagesNameView.vue
@@ -29,7 +29,7 @@ const submitSearch = () => {
       </button>
     </form>
     <div>
-      <RouterLink to="/home">メインメニューへ</RouterLink>
+      <RouterLink to="/home" ref="linkHome">メインメニューへ</RouterLink>
     </div>
   </div>
 </template>

--- a/frontend/test/components/HomeView.test.js
+++ b/frontend/test/components/HomeView.test.js
@@ -53,24 +53,17 @@ describe('HomeView', () => {
     })
   })
 
-  describe('Link Behavior', () => {
-    it('リンク要素が9個あること', () => {
-      const links = wrapper.findAll('a')
-      expect(links.length).toBe(9)
-    })
-
-    it('各リンクのto属性に間違いがないこと', () => {
-      const links = wrapper.findAll('a')
-
-      expect(links[0].attributes('href')).toBe('/static_pages/name')
-      expect(links[1].attributes('href')).toBe('/static_pages/category')
-      expect(links[2].attributes('href')).toBe('/static_pages/maker')
-      expect(links[3].attributes('href')).toBe('/list_search_results')
-      expect(links[4].attributes('href')).toBe('/samples')
-      expect(links[5].attributes('href')).toBe('/categories')
-      expect(links[6].attributes('href')).toBe('/makers')
-      expect(links[7].attributes('href')).toBe('/users')
-      expect(links[8].attributes('href')).toBe('/settings')
+  describe('リンク要素', () => {
+    it('RouterLinkにto属性が設定されていること', () => {
+      expect(wrapper.findComponent({ ref: "linkSearchName" }).props().to).toBe('/static_pages/name')
+      expect(wrapper.findComponent({ ref: "linkSearchCategory" }).props().to).toBe('/static_pages/category')
+      expect(wrapper.findComponent({ ref: "linkSearchMaker" }).props().to).toBe('/static_pages/maker')
+      expect(wrapper.findComponent({ ref: "linkSearchList" }).props().to).toBe('/list_search_results')
+      expect(wrapper.findComponent({ ref: "linkManageSamples" }).props().to).toBe('/samples')
+      expect(wrapper.findComponent({ ref: "linkManageCategories" }).props().to).toBe('/categories')
+      expect(wrapper.findComponent({ ref: "linkManageMakers" }).props().to).toBe('/makers')
+      expect(wrapper.findComponent({ ref: "linkManageUsers" }).props().to).toBe('/users')
+      expect(wrapper.findComponent({ ref: "linkSettings" }).props().to).toBe('/settings')
     })
   })
 

--- a/frontend/test/components/UsersEditView.test.js
+++ b/frontend/test/components/UsersEditView.test.js
@@ -50,11 +50,29 @@ describe('UsersEditView', () => {
       expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
     })
 
-    it('「ユーザー情報」と「ユーザーリスト」のリンクが表示されること', () => {
-      const wrapper = mount(UsersEditView)
+    it('外部リンクが表示されること', async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          id: 1,
+          name: 'test user',
+          department: '開発部'
+        }
+      })
 
-      expect(wrapper.find('routerlink[id="user_information"]').text()).toBe('ユーザー情報')
-      expect(wrapper.find('routerlink[id="user_list"]').text()).toBe('ユーザーリスト')
+      const wrapper = mount(UsersEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+
+      expect(wrapper.findComponent({ ref: 'linkUsersShow' }).props().to).toBe('/users/1')
+      expect(wrapper.findComponent({ ref: 'linkUsersShow' }).text()).toBe('ユーザー情報')
+      expect(wrapper.findComponent({ ref: 'linkUsers' }).props().to).toBe('/users')
+      expect(wrapper.findComponent({ ref: 'linkUsers' }).text()).toBe('ユーザーリスト')
     })
   })
 

--- a/frontend/test/components/UsersIndexView.test.js
+++ b/frontend/test/components/UsersIndexView.test.js
@@ -70,6 +70,11 @@ describe('UsersIndexView', () => {
       expect(wrapper.text()).toContain('前ページ')
       expect(wrapper.text()).toContain('次ページ')
     })
+
+    it('RouterLinkにto属性が設定されていること', () => {
+      expect(wrapper.findComponent({ ref: 'linkUsersNew' }).props().to).toBe('/users/new')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
+    })
   })
 
   describe('API通信', () => {

--- a/frontend/test/components/UsersNewView.test.js
+++ b/frontend/test/components/UsersNewView.test.js
@@ -49,8 +49,8 @@ describe('UsersNewView', () => {
       expect(wrapper.findAll('input[type="password"]').length).toBe(2)
     })
 
-    it('RouterLinkのto属性が/usersであること', () => {
-      expect(wrapper.find('a').attributes('href')).toBe('/users')
+    it('RouterLinkにto属性が設定されていること', () => {
+      expect(wrapper.findComponent({ ref: 'linkUsersNew' }).props().to).toBe('/users')
     })
   })
 

--- a/frontend/test/components/UsersShowView.test.js
+++ b/frontend/test/components/UsersShowView.test.js
@@ -58,6 +58,11 @@ describe('UsersShowView', () => {
       expect(elements[0].find('div:nth-child(2)').text()).toBe('test_user')
       expect(elements[1].find('div:nth-child(2)').text()).toBe('製造部')
     })
+
+    it('RouterLinkにto属性が設定されていること', () => {
+      expect(wrapper.findComponent({ ref: 'linkUsersEdit' }).props().to).toBe('/users/1/edit')
+      expect(wrapper.findComponent({ ref: 'linkUsers' }).props().to).toBe('/users')
+    })
   })
 
   describe('API通信', () => {

--- a/frontend/test/components/categories/CategoriesEditView.test.js
+++ b/frontend/test/components/categories/CategoriesEditView.test.js
@@ -27,7 +27,7 @@ vi.mock('vue-router', async () => {
 describe('コンポーネントをレンダリングした時に、', () => {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(async () => {
     axios.get.mockResolvedValue({
       data: {
         id: 1,
@@ -43,6 +43,8 @@ describe('コンポーネントをレンダリングした時に、', () => {
         }
       }
     })
+
+    await flushPromises()
   })
   
   it('見出し「カテゴリー情報の編集」が表示されること', () => {
@@ -58,18 +60,11 @@ describe('コンポーネントをレンダリングした時に、', () => {
     expect(wrapper.find('button').exists()).toBe(true)
   })
 
-  it('外部リンク「カテゴリー情報」と「カテゴリーリストへ」が表示されること', () => {
-    const links = wrapper.findAllComponents(RouterLinkStub)
-
-    expect(links[0].text()).toBe('カテゴリー情報へ')
-    expect(links[1].text()).toBe('カテゴリーリストへ')
-  })
-
-  it('外部リンク「カテゴリーリストへ」のto属性は/categoriesであること', () => {
-    const links = wrapper.findAllComponents(RouterLinkStub)
-
-    expect(links[0].props().to).toBe('/categories/1')
-    expect(links[1].props().to).toBe('/categories')
+  it('外部リンクが表示されること', () => {
+    expect(wrapper.findComponent({ ref: 'linkCategoriesShow' }).props().to).toBe('/categories/1')
+    expect(wrapper.findComponent({ ref: 'linkCategoriesShow' }).text()).toBe('カテゴリー情報へ')
+    expect(wrapper.findComponent({ ref: 'linkCategories' }).props().to).toBe('/categories')
+    expect(wrapper.findComponent({ ref: 'linkCategories' }).text()).toBe('カテゴリーリストへ')
   })
 
   it('「カテゴリー名」と「概要」の値が表示されること', () => {

--- a/frontend/test/components/categories/CategoriesIndexView.test.js
+++ b/frontend/test/components/categories/CategoriesIndexView.test.js
@@ -49,7 +49,17 @@ describe('CategoriesIndexView', () => {
   })
 
   describe('リンクの動作', () => {
-    it('メインメニューのリンクのto属性が/homeであること', async () => {
+    it('外部リンクが表示されること', async () => {
+      axios.get.mockResolvedValue({
+        data: [
+          { "id": 1, "item": "めっき" },
+          { "id": 2, "item": "陽極酸化" },
+          { "id": 3, "item": "化成" },
+          { "id": 4, "item": "コーティング" },
+          { "id": 5, "item": "表面硬化" }
+        ]
+      })
+
       const wrapper = mount(CategoriesIndexView, {
         global: {
           stubs: {
@@ -58,11 +68,12 @@ describe('CategoriesIndexView', () => {
         }
       })
 
-      const links = wrapper.findAllComponents(RouterLinkStub)
-      const link = links.find(element => element.text() === 'メインメニューへ')
+      await flushPromises()
 
-      expect(link).toBeDefined()
-      expect(link.props().to).toBe('/home')
+      expect(wrapper.findComponent({ ref: 'linkCategoriesNew' }).props().to).toBe('/categories/new')
+      expect(wrapper.findComponent({ ref: 'linkCategoriesNew' }).text()).toBe('カテゴリー情報の登録')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
     })
   })
 

--- a/frontend/test/components/categories/CategoriesNewView.test.js
+++ b/frontend/test/components/categories/CategoriesNewView.test.js
@@ -43,12 +43,9 @@ describe('コンポーネントをレンダリングした時に、', () => {
     expect(wrapper.find('button').exists()).toBe(true)
   })
 
-  it('外部リンク「カテゴリーリストへ」が表示されること', () => {
-    expect(wrapper.findComponent(RouterLinkStub).text()).toBe('カテゴリーリストへ')
-  })
-
-  it('外部リンク「カテゴリーリストへ」のto属性は/categoriesであること', () => {
-    expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/categories')
+  it('外部リンクが表示されること', () => {
+    expect(wrapper.findComponent({ ref: 'linkCategories' }).props().to).toBe('/categories')
+    expect(wrapper.findComponent({ ref: 'linkCategories' }).text()).toBe('カテゴリーリストへ')
   })
 })
 

--- a/frontend/test/components/categories/CategoriesShowView.test.js
+++ b/frontend/test/components/categories/CategoriesShowView.test.js
@@ -70,13 +70,13 @@ describe('CategoriesShowView', () => {
       expect(pElement.text()).toBe('カテゴリーの削除')
     })
 
-    it('RouterLinkのto属性が適切であること', async () => {
+    it('外部リンクが表示されること', async () => {
       await flushPromises()
 
-      const links = wrapper.findAllComponents(RouterLinkStub)
-
-      expect(links[0].props().to).toBe('/categories/1/edit')
-      expect(links[1].props().to).toBe('/categories')
+      expect(wrapper.findComponent({ ref: 'linkCategoriesEdit' }).props().to).toBe('/categories/1/edit')
+      expect(wrapper.findComponent({ ref: 'linkCategoriesEdit' }).text()).toBe('カテゴリー情報の編集')
+      expect(wrapper.findComponent({ ref: 'linkCategories' }).props().to).toBe('/categories')
+      expect(wrapper.findComponent({ ref: 'linkCategories' }).text()).toBe('カテゴリーリストへ')
     })
   })
 

--- a/frontend/test/components/makers/MakersEditView.test.js
+++ b/frontend/test/components/makers/MakersEditView.test.js
@@ -28,7 +28,7 @@ describe('MakersEditView', () => {
   describe('DOMの構造', () => {
     let wrapper
 
-    beforeEach(() => {
+    beforeEach(async () => {
       axios.get.mockResolvedValue({
         data: {
           id: 1,
@@ -50,6 +50,8 @@ describe('MakersEditView', () => {
           }
         }
       })
+
+      await flushPromises()
     })
 
     it('見出しが存在すること', () => {
@@ -103,11 +105,10 @@ describe('MakersEditView', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.findComponent('#maker_information').text()).toBe('メーカー情報へ')
-      expect(wrapper.findComponent('#maker_information').props().to).toBe('/makers/1')
-
-      expect(wrapper.findComponent('#maker_list').text()).toBe('メーカーリストへ')
-      expect(wrapper.findComponent('#maker_list').props().to).toBe('/makers')
+      expect(wrapper.findComponent({ref: 'linkMakersShow'}).text()).toBe('メーカー情報へ')
+      expect(wrapper.findComponent({ref: 'linkMakersShow'}).props().to).toBe('/makers/1')
+      expect(wrapper.findComponent({ref: 'linkMakers'}).text()).toBe('メーカーリストへ')
+      expect(wrapper.findComponent({ref: 'linkMakers'}).props().to).toBe('/makers')
     })
   })
 

--- a/frontend/test/components/makers/MakersEditView.test.js
+++ b/frontend/test/components/makers/MakersEditView.test.js
@@ -105,10 +105,10 @@ describe('MakersEditView', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.findComponent({ref: 'linkMakersShow'}).text()).toBe('メーカー情報へ')
-      expect(wrapper.findComponent({ref: 'linkMakersShow'}).props().to).toBe('/makers/1')
-      expect(wrapper.findComponent({ref: 'linkMakers'}).text()).toBe('メーカーリストへ')
-      expect(wrapper.findComponent({ref: 'linkMakers'}).props().to).toBe('/makers')
+      expect(wrapper.findComponent({ ref: 'linkMakersShow' }).text()).toBe('メーカー情報へ')
+      expect(wrapper.findComponent({ ref: 'linkMakersShow' }).props().to).toBe('/makers/1')
+      expect(wrapper.findComponent({ ref: 'linkMakers' }).text()).toBe('メーカーリストへ')
+      expect(wrapper.findComponent({ ref: 'linkMakers' }).props().to).toBe('/makers')
     })
   })
 

--- a/frontend/test/components/makers/MakersIndexView.test.js
+++ b/frontend/test/components/makers/MakersIndexView.test.js
@@ -23,35 +23,37 @@ vi.mock('vue-router', () => {
 })
 
 describe('MakersIndexView', () => {
-  let wrapper
-
-  beforeEach(() => {
-    axios.get.mockResolvedValue({ 
-      data: { 
-        makers: [
-          { "id": 1, "name": "有限会社中野銀行" },
-          { "id": 2, "name": "坂本建設有限会社" },
-          { "id": 3, "name": "合同会社中村食品" },
-          { "id": 4, "name": "合名会社武田印刷" },
-          { "id": 5, "name": "中川食品有限会社" },
-          { "id": 6, "name": "河野電気株式会社" },
-          { "id": 7, "name": "小山食品合同会社" },
-        ],
-        current_page: 1,
-        total_pages: 1
-      }
-    })
-
-    wrapper = mount(MakersIndexView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
-        }
-      }
-    })
-  })
-
   describe('コンポーネントのレンダリング', () => {
+    let wrapper
+
+    beforeEach(async () => {
+      axios.get.mockResolvedValue({ 
+        data: { 
+          makers: [
+            { "id": 1, "name": "有限会社中野銀行" },
+            { "id": 2, "name": "坂本建設有限会社" },
+            { "id": 3, "name": "合同会社中村食品" },
+            { "id": 4, "name": "合名会社武田印刷" },
+            { "id": 5, "name": "中川食品有限会社" },
+            { "id": 6, "name": "河野電気株式会社" },
+            { "id": 7, "name": "小山食品合同会社" },
+          ],
+          current_page: 1,
+          total_pages: 1
+        }
+      })
+
+      wrapper = mount(MakersIndexView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
     it('見出し「メーカーリスト」が表示されること', () => {
       expect(wrapper.find('h3').text()).toBe('メーカーリスト')
     })
@@ -82,18 +84,11 @@ describe('MakersIndexView', () => {
       expect(aElement[0].text()).toBe('1')
     })
 
-    it('外部リンク「メーカー情報の登録」と「メインメニュー」が表示されること', () => {
-      const links = wrapper.findAllComponents(RouterLinkStub)
-
-      expect(links[8].text()).toBe('メーカー情報の登録')
-      expect(links[9].text()).toBe('メインメニューへ')
-    })
-
-    it('外部リンクのto属性に「#」と「/home」が設定されていること', () => {
-      const links = wrapper.findAllComponents(RouterLinkStub)
-
-      expect(links[8].props().to).toBe('/makers/new')
-      expect(links[9].props().to).toBe('/home')
+    it('外部リンクが表示されること', () => {
+      expect(wrapper.findComponent({ ref: 'linkMakersNew' }).props().to).toBe('/makers/new')
+      expect(wrapper.findComponent({ ref: 'linkMakersNew' }).text()).toBe('メーカー情報の登録')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
     })
   })
   

--- a/frontend/test/components/makers/MakersNewView.test.js
+++ b/frontend/test/components/makers/MakersNewView.test.js
@@ -82,8 +82,8 @@ describe('MakersNewView', () => {
     })
 
     it('外部リンクが表示されること', () => {
-      expect(wrapper.findComponent(RouterLinkStub).text()).toBe('メーカーリストへ')
-      expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/makers')
+      expect(wrapper.findComponent({ ref: 'linkMakers' }).text()).toBe('メーカーリストへ')
+      expect(wrapper.findComponent({ ref: 'linkMakers' }).props().to).toBe('/makers')
     })
   })
   

--- a/frontend/test/components/makers/MakersShowView.test.js
+++ b/frontend/test/components/makers/MakersShowView.test.js
@@ -28,10 +28,10 @@ describe('MakersShowView', () => {
   describe('DOMの構造', () => {
     let wrapper
 
-    beforeEach(() => {
+    beforeEach(async() => {
       axios.get.mockResolvedValue({
         data: { 
-          id: '1',
+          id: 1,
           name: '有限会社中野銀行',
           postal_code: '962-0713',
           address: '東京都渋谷区神南1-2-0',
@@ -49,6 +49,8 @@ describe('MakersShowView', () => {
           }
         }
       })
+
+      await flushPromises()
     })
 
     it('見出しが表示されること', () => {
@@ -67,19 +69,10 @@ describe('MakersShowView', () => {
     })
 
     it('外部リンクが表示されること', () => {
-      expect(wrapper.find('#maker_edit').exists()).toBe(true)
-      expect(wrapper.find('#maker_edit').text()).toBe('メーカー情報の編集へ')
-      
-      expect(wrapper.find('#maker_destroy').exists()).toBe(true)
-      expect(wrapper.find('#maker_destroy').text()).toBe('メーカー情報の削除')
-      
-      expect(wrapper.find('#maker_list').exists()).toBe(true)
-      expect(wrapper.find('#maker_list').text()).toBe('メーカーリストへ')
-    })
-
-    it('外部リンクのto属性が適切であること', () => {
-      expect(wrapper.findComponent('#maker_edit').props().to).toBe('/makers/1/edit')
-      expect(wrapper.findComponent('#maker_list').props().to).toBe('/makers')
+      expect(wrapper.findComponent({ ref: 'linkMakersEdit' }).props().to).toBe('/makers/1/edit')
+      expect(wrapper.findComponent({ ref: 'linkMakersEdit' }).text()).toBe('メーカー情報の編集へ')
+      expect(wrapper.findComponent({ ref: 'linkMakers' }).props().to).toBe('/makers')
+      expect(wrapper.findComponent({ ref: 'linkMakers' }).text()).toBe('メーカーリストへ')
     })
   })
 

--- a/frontend/test/components/samples/SamplesEditView.test.js
+++ b/frontend/test/components/samples/SamplesEditView.test.js
@@ -28,7 +28,7 @@ describe('SamplesEditView', () => {
   describe('DOMの構造', () => {
     axios.get.mockResolvedValue({
       data: {
-        id: 35,
+        id: 1,
         name: "無電解ニッケルめっき",
         category: "めっき",
         color: "コールド",
@@ -44,7 +44,7 @@ describe('SamplesEditView', () => {
 
     let wrapper
 
-    beforeEach(() => {
+    beforeEach(async () => {
       wrapper = mount(SamplesEditView, {
         global: {
           stubs: {
@@ -52,6 +52,8 @@ describe('SamplesEditView', () => {
           }
         }
       })
+
+      await flushPromises()
     })
 
     it('見出しが存在すること', () => {
@@ -105,13 +107,12 @@ describe('SamplesEditView', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.find('#sample_show').exists()).toBe(true)
-      expect(wrapper.find('#sample_show').text()).toBe('表面処理情報へ')
-      expect(wrapper.findComponent('#sample_show').props().to).toBe('/samples/35')
-      
-      expect(wrapper.find('#sample_list').exists()).toBe(true)
-      expect(wrapper.find('#sample_list').text()).toBe('表面処理リストへ')
-      expect(wrapper.findComponent('#sample_list').props().to).toBe('/samples')
+      expect(wrapper.findComponent({ ref: 'linkSamplesEdit' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ ref: 'linkSamplesEdit' }).text()).toBe('表面処理情報へ')
+      expect(wrapper.findComponent({ ref: 'linkSamplesEdit' }).props().to).toBe('/samples/1')      
+      expect(wrapper.findComponent({ ref: 'linkSamples' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ ref: 'linkSamples' }).text()).toBe('表面処理リストへ')
+      expect(wrapper.findComponent({ ref: 'linkSamples' }).props().to).toBe('/samples')
     })    
   })
 

--- a/frontend/test/components/samples/SamplesIndexView.test.js
+++ b/frontend/test/components/samples/SamplesIndexView.test.js
@@ -26,7 +26,23 @@ describe('SamplesIndexView', () => {
   let wrapper
 
   describe('DOMの構造', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          samples: [
+            { "id": 1, "name": "無電解ニッケルめっき" },
+            { "id": 2, "name": "白金めっき" },
+            { "id": 3, "name": "金めっき" },
+            { "id": 4, "name": "銀めっき" },
+            { "id": 5, "name": "銅めっき" },
+            { "id": 6, "name": "亜鉛めっき" },
+            { "id": 7, "name": "錫めっき" },
+          ],
+          curent_page: 1,
+          total_pages: 1
+        }
+      })
+      
       wrapper = mount(SamplesIndexView, {
         global: {
           stubs: {
@@ -34,6 +50,8 @@ describe('SamplesIndexView', () => {
           }
         }
       })
+
+      await flushPromises()
     })
 
     it('見出しが存在すること', () => {
@@ -53,14 +71,13 @@ describe('SamplesIndexView', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.findComponent('#link_samples_new').text()).toBe('表面処理情報の登録')
-      expect(wrapper.findComponent('#link_samples_new').props().to).toBe('/samples/new')
-
-      expect(wrapper.findComponent('#link_home').text()).toBe('メインメニューへ')
-      expect(wrapper.findComponent('#link_home').props().to).toBe('/home')
+      expect(wrapper.findComponent({ ref: 'linkSamplesNew' }).text()).toBe('表面処理情報の登録')
+      expect(wrapper.findComponent({ ref: 'linkSamplesNew' }).props().to).toBe('/samples/new')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
     })
   })
-
+    
   describe('API通信', () => {
     describe('表面処理リストの取得に成功した場合', () => {
       it('表面処理リストが7件表示されること', async () => {

--- a/frontend/test/components/samples/SamplesNewView.test.js
+++ b/frontend/test/components/samples/SamplesNewView.test.js
@@ -96,7 +96,7 @@ describe('SamplesNewView', () => {
 
     it('外部リンクが存在すること', () => {
       expect(wrapper.findComponent({ ref: 'linkSamples' }).props().to).toBe('/samples')
-
+      expect(wrapper.findComponent({ ref: 'linkSamples' }).text()).toBe('表面処理リストへ')
     })
   })
 

--- a/frontend/test/components/samples/SamplesNewView.test.js
+++ b/frontend/test/components/samples/SamplesNewView.test.js
@@ -95,8 +95,8 @@ describe('SamplesNewView', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
-      expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/samples')
+      expect(wrapper.findComponent({ ref: 'linkSamples' }).props().to).toBe('/samples')
+
     })
   })
 

--- a/frontend/test/components/samples/SamplesShowView.test.js
+++ b/frontend/test/components/samples/SamplesShowView.test.js
@@ -28,7 +28,7 @@ describe('SamplesShowView', () => {
   describe('DOMの構造', () => {
     let wrapper
 
-    beforeEach(() => {
+    beforeEach(async () => {
       axios.get.mockReturnValue({
         data: {
           "id": 1,
@@ -52,6 +52,8 @@ describe('SamplesShowView', () => {
           }
         }
       })
+
+      await flushPromises()
     })
 
     it('見出しが表示されること', () => {
@@ -86,9 +88,10 @@ describe('SamplesShowView', () => {
     })
 
     it('外部リンクが表示されること', () => {
-      expect(wrapper.find('#link_sample_edit').text()).toBe('表面処理情報の編集')
-      expect(wrapper.find('#link_sample_destroy').text()).toBe('表面処理情報の削除')
-      expect(wrapper.find('#link_samples').text()).toBe('表面処理リストへ')
+      expect(wrapper.findComponent({ ref: 'linkSamplesEdit' }).props().to).toBe('/samples/1/edit')
+      expect(wrapper.findComponent({ ref: 'linkSamplesEdit' }).text()).toBe('表面処理情報の編集')
+      expect(wrapper.findComponent({ ref: 'linkSamples' }).props().to).toBe('/samples')
+      expect(wrapper.findComponent({ ref: 'linkSamples' }).text()).toBe('表面処理リストへ')
     })
   })
 

--- a/frontend/test/components/static_pages/StaticPagesCategoryView.test.js
+++ b/frontend/test/components/static_pages/StaticPagesCategoryView.test.js
@@ -62,9 +62,9 @@ describe('StaticPagesCategory', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
-      expect(wrapper.findComponent(RouterLinkStub).text()).toBe('メインメニューへ')
-      expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/home')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
     })
   })
 

--- a/frontend/test/components/static_pages/StaticPagesNameView.test.js
+++ b/frontend/test/components/static_pages/StaticPagesNameView.test.js
@@ -50,9 +50,9 @@ describe('StaticPagesNameView', () => {
     })
 
     it('外部リンクが存在すること', () => {
-      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
-      expect(wrapper.findComponent(RouterLinkStub).text()).toBe('メインメニューへ')
-      expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/home')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
+      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
     })
   })
 


### PR DESCRIPTION
## 対象のコンポーネント
- [x] HomeView.vue
- [x] users
  - [x] UsersIndexView.vue
  - [x] UsersShowView.vue
  - [x] UsersNewView.vue
  - [x] UsersEditView.vue
- [x] categories
  - [x] CategoriesIndexView.vue
  - [x] CategoriesShowView.vue
  - [x] CategoriesNewView.vue
  - [x] CategoriesEditView.vue
- [x] makers
  - [x] MakersIndexView.vue
  - [x] MakersShowView.vue
  - [x] MakersNewView.vue
  - [x] MakersEditView.vue
- [x] samples
  - [x] SamplesIndexView.vue
  - [x] SamplesShowView.vue
  - [x] SamplesNewView.vue
  - [x] SamplesEditView.vue
- [x] search_results
  - [x] SearchResultsListView.vue
  - [x] SearchResultsView.vue
- [x] static_pages
  - [x] StaticPagesCategoryView.vue
  - [x] StaticPagesMakerView.vue
  - [x] StaticPagesNameView.vue

#### 追加タスク
- [x] users view のコミットを1つにまとめる
- [x] static pages view のコミットを1つにまとめる
- [x] MakersEditView.test.js ref に空白追加