### PR TITLE
UsersNewView のドロップダウンリスト修正

### DIFF
--- a/backend/app/controllers/departments_controller.rb
+++ b/backend/app/controllers/departments_controller.rb
@@ -1,0 +1,46 @@
+class DepartmentsController < ApplicationController
+  def index
+    departments = Department.order(:id)
+
+    render json: departments, status: :ok
+  end
+
+  def show
+    department = Department.find(params[:id])
+
+    render json: department, status: :ok
+  end
+
+  def create
+    department = Department.new(department_params)
+
+    if department.save
+      render json: department, status: :created, location: department
+    else
+      render json: department.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    department = Department.find(params[:id])
+
+    if department.update(department_params) 
+      render json: department, status: :ok
+    else
+      render json: department.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    department = Department.find(params[:id])
+    department.destroy
+
+    head :no_content
+  end
+
+  private
+
+    def department_params
+      params.require(:department).permit(:name)
+    end
+end

--- a/backend/app/models/department.rb
+++ b/backend/app/models/department.rb
@@ -1,0 +1,2 @@
+class Department < ApplicationRecord
+end

--- a/backend/app/models/department.rb
+++ b/backend/app/models/department.rb
@@ -1,2 +1,4 @@
 class Department < ApplicationRecord
+  validates :name, presence:   { message: '部署名が空白です。' },
+                   uniqueness: { message: '部署名が重複しています。' }
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :categories
   resources :makers
   resources :users
+  resources :departments
 
   resources :samples do
     resources :comments

--- a/backend/db/migrate/20250621195108_create_departments.rb
+++ b/backend/db/migrate/20250621195108_create_departments.rb
@@ -1,0 +1,9 @@
+class CreateDepartments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :departments do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_05_012249) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_21_195108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_05_012249) do
     t.datetime "updated_at", null: false
     t.string "department"
     t.index ["sample_id"], name: "index_comments_on_sample_id"
+  end
+
+  create_table "departments", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "makers", force: :cascade do |t|

--- a/backend/spec/factories/departments.rb
+++ b/backend/spec/factories/departments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :department do
+    name { "MyString" }
+  end
+end

--- a/backend/spec/factories/departments.rb
+++ b/backend/spec/factories/departments.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :department do
-    name { "MyString" }
+    name { '品質管理部' }
   end
 end

--- a/backend/spec/models/department_spec.rb
+++ b/backend/spec/models/department_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Department, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/department_spec.rb
+++ b/backend/spec/models/department_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Department, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validation' do
+    before do
+      @department = FactoryBot.build(:department)
+    end
+
+    it 'nameが存在すること' do
+      @department.name = ''
+      expect(@department).to_not be_valid
+    end
+
+    it 'nameの重複がないこと' do
+      @department.save
+      duplicate_department = @department.dup
+      expect(duplicate_department).to_not be_valid
+    end
+  end
 end

--- a/backend/spec/requests/departments_spec.rb
+++ b/backend/spec/requests/departments_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe "Departments", type: :request do
+  describe "#index" do
+    before do
+      FactoryBot.create(:department, name: '品質管理部')
+      FactoryBot.create(:department, name: '製造部')
+      FactoryBot.create(:department, name: '開発部')
+      FactoryBot.create(:department, name: '営業部')
+    end
+
+    it "レスポンスのステータスがokであること" do
+      get "/departments"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '部署名が4件返ること' do
+      get "/departments"
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json.count).to eq(4)
+    end
+
+    it '部署名リストの並び順はidの昇順であること' do
+      get "/departments"
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json[0][:name]).to eq('品質管理部')
+      expect(json[1][:name]).to eq('製造部')
+      expect(json[2][:name]).to eq('開発部')
+      expect(json[3][:name]).to eq('営業部')
+    end
+  end
+
+  describe '#show' do
+    before do
+      @department = FactoryBot.create(:department)
+    end
+
+    it 'レスポンスのステータスがokであること' do
+      get "/departments/#{@department.id}/"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '部署名が返ること' do
+      get "/departments/#{@department.id}/"
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json[:name]).to eq('品質管理部')
+    end
+  end
+
+  describe '#create' do
+    before do
+      @valid_department_params = { department: { name: '品質保証部'} }
+    end
+
+    context '有効な部署名で登録したとき' do
+      it 'レスポンスのステータスがcreatedであること' do
+        post "/departments", params: @valid_department_params
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'headerのlocationが登録した部署名を参照していること' do
+        post "/departments", params: @valid_department_params
+        department = Department.last
+        expect(response.header["Location"]).to eq("http://www.example.com/departments/#{department.id}")
+      end
+
+      it 'データベースのレコード数が1件増えること' do
+        expect{ post "/departments", params: @valid_department_params }.to change{ Department.count }.from(0).to(1)
+      end
+    end
+  end
+
+  describe '#pudate' do
+    before do
+      @department = FactoryBot.create(:department)      
+    end
+    
+    context '有効な部署名で更新したとき' do
+      it 'レスポンスのステータスがokであること' do
+        patch "/departments/#{@department.id}", params: { department: { name: '営業部'} }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'nameが営業部で更新されること' do
+        patch "/departments/#{@department.id}", params: { department: { name: '営業部'} }
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(json[:name]).to eq('営業部')
+      end      
+    end
+  end
+
+
+  describe '#destroy' do
+    before do
+      @department = FactoryBot.create(:department)      
+    end
+
+    it 'レスポンスのステータスがno_contentであること' do
+      delete "/departments/#{@department.id}"
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'レスポンスの本文が空であること' do
+      delete "/departments/#{@department.id}"
+      expect(response.body).to be_blank
+    end
+
+    it '部署名の削除に成功すること' do
+      expect { delete "/departments/#{@department.id}" }.to change{ Department.count }.from(1).to(0)
+    end
+  end
+end

--- a/frontend/src/components/users/UsersNewView.vue
+++ b/frontend/src/components/users/UsersNewView.vue
@@ -1,25 +1,30 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import axios from 'axios'
 import { useRouter } from 'vue-router'
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 const emit = defineEmits(['message'])
 const router = useRouter()
+const options = ref([])
+const user = ref('')
 const name = ref('')
 const department = ref('')
 const password = ref('')
 const password_confirmation = ref('')
 const errorMessage = ref('')
 
-const options = ref([
-  { text: '品質管理部', value: '品質管理部' },
-  { text: '製造部', value: '製造部' },
-  { text: '開発部', value: '開発部' },
-  { text: '営業部', value: '営業部' },
-])
-
-const user = ref('')
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const fetchDepartments = async () => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/departments`)
+    options.value = response.data
+  } catch (error) {
+    if (error.response && error.response.status === 404) {
+      emit('message', { type: 'danger', text: '部署名の取得に失敗しました。' })
+      router.replace({ name: 'NotFound' })
+    }
+  }
+}
 
 const userRegistration = async () => {
   try {
@@ -38,6 +43,10 @@ const userRegistration = async () => {
     errorMessage.value = '入力に不備があります。'
   }
 }
+
+onMounted(() => {
+  fetchDepartments()
+})
 </script>
 
 <template>
@@ -68,8 +77,8 @@ const userRegistration = async () => {
         required
       >
         <option value="" label=" "></option>
-        <option v-for="option in options" v-bind:value="option.value">
-          {{ option.text }}
+        <option v-for="option in options" v-bind:key="option.id" v-bind:value="option.name">
+          {{ option.name }}
         </option>
       </select>
 

--- a/frontend/src/components/users/UsersNewView.vue
+++ b/frontend/src/components/users/UsersNewView.vue
@@ -76,7 +76,9 @@ onMounted(() => {
         id="user-department"
         required
       >
-        <option value="" label=" "></option>
+        <option value="">
+          部署名を選択して下さい
+        </option>
         <option v-for="option in options" v-bind:key="option.id" v-bind:value="option.name">
           {{ option.name }}
         </option>


### PR DESCRIPTION
## タスク
- backend
  - [x] department リソースの作成
    - [x] コントローラ
    - [x] コントローラ　テスト（残りは update の失敗のパターン）
    - [x] ルーティング
    - [x] モデル
- frontend
  - UsersNewView の修正
    - [x] データベースに「製造部」「開発部」「営業部」を追加
    - [x] マウント時に department リソースを取得
    - [x] 取得したリソースをオプション要素にセット