### PR TITLE
categories コンポーネントテストの構造化見直し

### DIFF
--- a/frontend/src/components/categories/CategoriesShowView.vue
+++ b/frontend/src/components/categories/CategoriesShowView.vue
@@ -65,7 +65,7 @@ onMounted(() => {
         カテゴリー情報の編集
       </RouterLink>
       <p v-on:click="handleDelete" class="text-primary text-decoration-underline">
-        カテゴリーの削除
+        カテゴリー情報の削除
       </p>
       <RouterLink to="/categories" ref="linkCategories">
         カテゴリーリストへ

--- a/frontend/test/components/categories/CategoriesEditView.test.js
+++ b/frontend/test/components/categories/CategoriesEditView.test.js
@@ -1,13 +1,12 @@
-import { describe, it, expect,  vi, beforeEach } from 'vitest'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import CategoriesEditView from '@/components/categories/CategoriesEditView.vue'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, it, expect,  vi, beforeEach } from 'vitest'
 import axios from 'axios'
-
-vi.mock('axios')
 
 const replaceMock = vi.fn()
 const pushMock = vi.fn()
 
+vi.mock('axios')
 vi.mock('vue-router', async () => {
   return {
     useRoute: () => {
@@ -24,161 +23,179 @@ vi.mock('vue-router', async () => {
   }
 })
 
-describe('コンポーネントをレンダリングした時に、', () => {
+describe('CategoriesEditView', () => {
   let wrapper
 
-  beforeEach(async () => {
-    axios.get.mockResolvedValue({
-      data: {
-        id: 1,
-        item: 'めっき',
-        summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
-      }
-    })
-
-    wrapper = mount(CategoriesEditView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
+  describe('初期レンダリングに成功した場合', () => {
+    beforeEach(async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          id: 1,
+          item: 'めっき',
+          summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
         }
-      }
-    })
+      })
 
-    await flushPromises()
-  })
-  
-  it('見出し「カテゴリー情報の編集」が表示されること', () => {
-    expect(wrapper.find('h3').text()).toBe('カテゴリー情報の編集')
-  })
-
-  it('入力フォームが表示されること', () => {
-    expect(wrapper.find('form').exists()).toBe(true)
-    expect(wrapper.find('label[for="category-item"]').text()).toBe('カテゴリー名')
-    expect(wrapper.find('label[for="category-summary"]').text()).toBe('概要')
-    expect(wrapper.find('input[id="category-item"]').exists()).toBe(true)
-    expect(wrapper.find('textarea[id="category-summary"]').exists()).toBe(true)
-    expect(wrapper.find('button').exists()).toBe(true)
-  })
-
-  it('外部リンクが表示されること', () => {
-    expect(wrapper.findComponent({ ref: 'linkCategoriesShow' }).props().to).toBe('/categories/1')
-    expect(wrapper.findComponent({ ref: 'linkCategoriesShow' }).text()).toBe('カテゴリー情報へ')
-    expect(wrapper.findComponent({ ref: 'linkCategories' }).props().to).toBe('/categories')
-    expect(wrapper.findComponent({ ref: 'linkCategories' }).text()).toBe('カテゴリーリストへ')
-  })
-
-  it('「カテゴリー名」と「概要」の値が表示されること', () => {
-    expect(wrapper.vm.category.item).toBe('めっき')
-    expect(wrapper.vm.category.summary).toBe('金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。')    
-  })
-})
-
-describe('カテゴリー情報の取得に成功した場合', () => {
-  it('カテゴリー名と概要が表示されること', async () => {
-    axios.get.mockResolvedValue({
-      data: {
-        id: 1,
-        item: 'sample category',
-        summary: 'sample summary'
-      }
-    })
-
-    const wrapper = mount(CategoriesEditView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub 
+      wrapper = mount(CategoriesEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
         }
-      }
+      })
+
+      await flushPromises()
+    })
+    
+    it('見出しが表示されること', () => {
+      expect(wrapper.find('h3').text()).toBe('カテゴリー情報の編集')
     })
 
-    await flushPromises()
+    it('入力フォームが表示されること', () => {
+      // フォーム要素
+      expect(wrapper.find('form').exists()).toBe(true)
 
-    expect(wrapper.find('#category-item').element.value).toBe('sample category')
-    expect(wrapper.find('#category-summary').element.value).toBe('sample summary')
+      // ラベル要素
+      expect(wrapper.find('label[for="category-item"]').text()).toBe('カテゴリー名')
+      expect(wrapper.find('label[for="category-summary"]').text()).toBe('概要')
+
+      // 入力要素
+      expect(wrapper.find('#category-item').exists()).toBe(true)
+      expect(wrapper.find('#category-item').element.value).toBe('めっき')
+
+      // テキストエリア要素
+      expect(wrapper.find('#category-summary').exists()).toBe(true)
+      expect(wrapper.find('#category-summary').element.value).toBe('金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。')
+
+      // ボタン要素
+      expect(wrapper.find('button').text()).toBe('更新')
+    })
+
+    it('外部リンクが表示されること', () => {
+      const linkCategoriesShow = wrapper.findComponent({ ref: 'linkCategoriesShow' })
+      const linkCategories = wrapper.findComponent({ ref: 'linkCategories' })
+
+      // to属性
+      expect(linkCategoriesShow.props().to).toBe('/categories/1')
+      expect(linkCategories.props().to).toBe('/categories')
+
+      // テキスト
+      expect(linkCategoriesShow.text()).toBe('カテゴリー情報へ')
+      expect(linkCategories.text()).toBe('カテゴリーリストへ')
+    })
   })
-})
 
-describe('カテゴリー情報の取得に失敗した場合', () => {
-  it('404ページに遷移すること', async () => {
-    axios.get.mockRejectedValue({
-      response: {
-        status: 404
-      }
-    })
-
-    const wrapper = mount(CategoriesEditView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
+  describe('初期レンダリングに失敗した場合', () => {
+    it('404ページに遷移すること', async () => {
+      axios.get.mockRejectedValue({
+        response: {
+          status: 404
         }
-      }
+      })
+
+      wrapper = mount(CategoriesEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('message')
+      expect(wrapper.emitted().message[0]).toEqual([
+        { type: 'danger', text: 'カテゴリー情報の取得に失敗しました。' }
+      ])
+      expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
     })
-
-    await flushPromises()
-
-    expect(wrapper.emitted()).toHaveProperty('message')
-    expect(wrapper.emitted().message[0]).toEqual([
-      { type: 'danger', text: 'カテゴリー情報の取得に失敗しました。' }
-    ])
-    expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
   })
-})
 
-
-describe('有効なデータを入力して更新ボタンを押した場合', () => {
-  it('更新が成功してカテゴリー情報のページに遷移すること', async () => {
-    axios.get.mockResolvedValue({
-      data: {
-        id: 1,
-        item: 'めっき',
-        summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
-      }
-    })
-
-    axios.patch.mockResolvedValue({
-      data: {
-        id: 1,
-        item: 'めっき（更新後）',
-        summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
-      }
-    })
-
-    const wrapper = mount(CategoriesEditView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
+  describe('有効な情報を送信した場合', () => {
+    it('更新が成功すること', async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          id: 1,
+          item: 'めっき',
+          summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
         }
-      }
+      })
+
+      axios.patch.mockResolvedValue({
+        data: {
+          id: 1,
+          item: '陽極酸化',
+          summary: '人工的にアルミニウム表面に分厚い酸化アルミニウム被膜を作る処理のこと。'
+        }
+      })
+
+      wrapper = mount(CategoriesEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+
+      const inputItem = wrapper.find('#category-item')
+      const inputSummary = wrapper.find('#category-summary')
+      
+      expect(inputItem.element.value).toBe('めっき')
+      expect(inputSummary.element.value).toBe('金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。')
+      
+      await inputItem.setValue('陽極酸化')
+      await inputSummary.setValue('人工的にアルミニウム表面に分厚い酸化アルミニウム被膜を作る処理のこと。')
+
+      await wrapper.find('form').trigger('submit.prevent')
+
+      expect(wrapper.emitted()).toHaveProperty('message')
+      expect(wrapper.emitted().message[0]).toEqual([
+        { type: 'success', text: 'カテゴリー情報を更新しました。' }
+      ])
+      expect(pushMock).toHaveBeenCalledWith('/categories/1')
     })
-
-    await flushPromises()
-
-    await wrapper.find('form').trigger('submit.prevent')
-
-    expect(wrapper.emitted()).toHaveProperty('message')
-    expect(wrapper.emitted().message[0]).toEqual([
-      { type: 'success', text: 'カテゴリー情報を更新しました。' }
-    ])
-    expect(pushMock).toHaveBeenCalledWith('/categories/1')
   })
-})
 
-describe('無効なデータを入力して更新ボタンを押した場合', () => {
-  it('入力不備のメッセージが表示されること', async () => {
-    axios.patch.mockRejectedValue(new Error('Invalid credentials'))
-
-    const wrapper = mount(CategoriesEditView, {
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub
+  describe('無効な情報を送信した場合', () => {
+    it('更新が失敗すること', async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          id: 1,
+          item: 'めっき',
+          summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
         }
-      }
+      })
+
+      axios.patch.mockRejectedValue({
+        response: {
+          status: 422
+        }
+      })
+
+      wrapper = mount(CategoriesEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+
+      const inputItem = wrapper.find('#category-item')
+      const inputSummary = wrapper.find('#category-summary')
+      
+      expect(inputItem.element.value).toBe('めっき')
+      expect(inputSummary.element.value).toBe('金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。')
+      
+      await inputItem.setValue('')
+      await inputSummary.setValue('人工的にアルミニウム表面に分厚い酸化アルミニウム被膜を作る処理のこと。')
+
+      await wrapper.find('form').trigger('submit.prevent')
+
+      expect(wrapper.text()).toContain('入力に不備があります。')
     })
-
-    await flushPromises()
-
-    await wrapper.find('form').trigger('submit.prevent')
-
-    expect(wrapper.text()).toContain('入力に不備があります。')
   })
 })

--- a/frontend/test/components/categories/CategoriesIndexView.test.js
+++ b/frontend/test/components/categories/CategoriesIndexView.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import CategoriesIndexView from '@/components/categories/CategoriesIndexView.vue'
 import axios from 'axios'
@@ -6,7 +6,6 @@ import axios from 'axios'
 const replaceMock = vi.fn()
 
 vi.mock('axios')
-
 vi.mock('vue-router', () => {
   return {
     useRouter: () => {
@@ -18,46 +17,96 @@ vi.mock('vue-router', () => {
 })
 
 describe('CategoriesIndexView', () => {
-  describe('コンポーネントのレンダリング', () => {
-    it('「カテゴリーリスト」の見出しが表示されること', () => {
-      const wrapper = mount(CategoriesIndexView)
+  let wrapper
 
-      expect(wrapper.find('h3').text()).toBe('カテゴリーリスト')
-    })
+  describe('初期レンダリングに成功した場合', () => {
+    beforeEach(async () => {
+      axios.get.mockResolvedValue({
+        data: [
+          {
+            id: 1,
+            item: 'めっき',
+            summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
+          },
+          {
+            id: 2,
+            item: '陽極酸化',
+            summary: '人工的にアルミニウム表面に分厚い酸化アルミニウム被膜を作る処理のこと。'
+          },
+          {
+            id: 3,
+            item: '化成',
+            summary: '金属の表面に処理剤を作用させて化学反応を起こさせる処理のこと。'
+          },
+          {
+            id: 4,
+            item: 'コーティング',
+            summary: '溶射金属やセラミックスの粉末を、溶解状態にして製品表面に吹き付ける処理のこと。'
+          },
+          {
+            id: 5,
+            item: '表面硬化',
+            summary: '主に金属材料に対して行われる、加熱・冷却・雰囲気により材料の性質を変化させる処理のこと。'
+          }
+        ]
+      })
 
-    it('「カテゴリー名」と「概要」のラベルが表示されること', () => {
-      const wrapper = mount(CategoriesIndexView)
-      const links = wrapper.findAll('h6')
-
-      expect(links[0].text()).toBe('カテゴリー名')
-      expect(links[1].text()).toBe('概要')
-    })
-
-    it('「カテゴリー情報の登録」と「メインメニューへ」のリンクが表示されること', () => {
-      const wrapper = mount(CategoriesIndexView, {
+      wrapper = mount(CategoriesIndexView, {
         global: {
           stubs: {
             RouterLink: RouterLinkStub
           }
         }
       })
-      const links = wrapper.findAll('a')
 
-      expect(links[0].text()).toBe('カテゴリー情報の登録')
-      expect(links[1].text()).toBe('メインメニューへ')
+      await flushPromises()
+    })
+
+    it('見出しが表示されること', () => {
+      expect(wrapper.find('h3').text()).toBe('カテゴリーリスト')
+    })
+
+    it('ラベルが表示されること', () => {
+      expect(wrapper.text()).toContain('カテゴリー名')
+      expect(wrapper.text()).toContain('概要')
+    })
+
+    it('カテゴリーリストが表示されること', () => {
+      // カテゴリー名
+      expect(wrapper.text()).toContain('めっき')
+      expect(wrapper.text()).toContain('陽極酸化')
+      expect(wrapper.text()).toContain('化成')
+      expect(wrapper.text()).toContain('コーティング')
+      expect(wrapper.text()).toContain('表面硬化')
+
+      // 概要
+      expect(wrapper.text()).toContain('金属または非金属の材...')
+      expect(wrapper.text()).toContain('人工的にアルミニウム...')
+      expect(wrapper.text()).toContain('金属の表面に処理剤を...')
+      expect(wrapper.text()).toContain('溶射金属やセラミック...')
+      expect(wrapper.text()).toContain('主に金属材料に対して...')
+    })
+
+    it('外部リンクが表示されること', () => {
+      const linkCategoriesNew = wrapper.findComponent({ ref: 'linkCategoriesNew' })
+      const linkHome = wrapper.findComponent({ ref: 'linkHome' })
+      
+      // to属性
+      expect(linkCategoriesNew.props().to).toBe('/categories/new')
+      expect(linkHome.props().to).toBe('/home')
+      
+      // テキスト
+      expect(linkCategoriesNew.text()).toBe('カテゴリー情報の登録')
+      expect(linkHome.text()).toBe('メインメニューへ')
     })
   })
 
-  describe('リンクの動作', () => {
-    it('外部リンクが表示されること', async () => {
-      axios.get.mockResolvedValue({
-        data: [
-          { 'id': 1, 'item': 'めっき' },
-          { 'id': 2, 'item': '陽極酸化' },
-          { 'id': 3, 'item': '化成' },
-          { 'id': 4, 'item': 'コーティング' },
-          { 'id': 5, 'item': '表面硬化' }
-        ]
+  describe('初期レンダリングに失敗した場合', () => {
+    it('404ページに遷移すること', async () => {
+      axios.get.mockRejectedValue({
+        response: {
+          status: 404
+        }
       })
 
       const wrapper = mount(CategoriesIndexView, {
@@ -70,68 +119,11 @@ describe('CategoriesIndexView', () => {
 
       await flushPromises()
 
-      expect(wrapper.findComponent({ ref: 'linkCategoriesNew' }).props().to).toBe('/categories/new')
-      expect(wrapper.findComponent({ ref: 'linkCategoriesNew' }).text()).toBe('カテゴリー情報の登録')
-      expect(wrapper.findComponent({ ref: 'linkHome' }).props().to).toBe('/home')
-      expect(wrapper.findComponent({ ref: 'linkHome' }).text()).toBe('メインメニューへ')
-    })
-  })
-
-  describe('API通信', () => {
-    describe('カテゴリーリストの取得に成功した場合', () => {
-      it('カテゴリーの一覧が表示されること', async () => {
-        axios.get.mockResolvedValue({
-          data: [
-            { 'id': 1, 'item': 'めっき' },
-            { 'id': 2, 'item': '陽極酸化' },
-            { 'id': 3, 'item': '化成' },
-            { 'id': 4, 'item': 'コーティング' },
-            { 'id': 5, 'item': '表面硬化' }
-          ]
-        })
-
-        const wrapper = mount(CategoriesIndexView, {
-          global: {
-            stubs: {
-              RouterLink: RouterLinkStub
-            }
-          }
-        })
-
-        await flushPromises()
-
-        expect(wrapper.text()).toContain('めっき')
-        expect(wrapper.text()).toContain('陽極酸化')
-        expect(wrapper.text()).toContain('化成')
-        expect(wrapper.text()).toContain('コーティング')
-        expect(wrapper.text()).toContain('表面硬化')
-      })
-    })
-
-    describe('カテゴリーリストの取得に失敗した場合', () => {
-      it('404ページに遷移すること', async () => {
-        axios.get.mockRejectedValue({
-          response: {
-            status: 404
-          }
-        })
-
-        const wrapper = mount(CategoriesIndexView, {
-          global: {
-            stubs: {
-              RouterLink: RouterLinkStub
-            }
-          }
-        })
-
-        await flushPromises()
-
-        expect(wrapper.emitted()).toHaveProperty('message')
-        expect(wrapper.emitted().message[0]).toEqual([
-          { type: 'danger', text: 'カテゴリーの取得に失敗しました。' }
-        ])
-        expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
-      })
+      expect(wrapper.emitted()).toHaveProperty('message')
+      expect(wrapper.emitted().message[0]).toEqual([
+        { type: 'danger', text: 'カテゴリーの取得に失敗しました。' }
+      ])
+      expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
     })
   })
 })

--- a/frontend/test/components/categories/CategoriesIndexView.test.js
+++ b/frontend/test/components/categories/CategoriesIndexView.test.js
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import CategoriesIndexView from '@/components/categories/CategoriesIndexView.vue'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from 'axios'
 
 const replaceMock = vi.fn()
@@ -66,11 +66,6 @@ describe('CategoriesIndexView', () => {
       expect(wrapper.find('h3').text()).toBe('カテゴリーリスト')
     })
 
-    it('ラベルが表示されること', () => {
-      expect(wrapper.text()).toContain('カテゴリー名')
-      expect(wrapper.text()).toContain('概要')
-    })
-
     it('カテゴリーリストが表示されること', () => {
       // カテゴリー名
       expect(wrapper.text()).toContain('めっき')
@@ -109,7 +104,7 @@ describe('CategoriesIndexView', () => {
         }
       })
 
-      const wrapper = mount(CategoriesIndexView, {
+      wrapper = mount(CategoriesIndexView, {
         global: {
           stubs: {
             RouterLink: RouterLinkStub

--- a/frontend/test/components/categories/CategoriesNewView.test.js
+++ b/frontend/test/components/categories/CategoriesNewView.test.js
@@ -43,11 +43,11 @@ describe('CategoriesNewView', () => {
       expect(wrapper.find('label[for="category-summary"]').text()).toBe('概要')
 
       // 入力要素・テキストエリア要素
-      expect(wrapper.find('input[id="category-item"]').exists()).toBe(true)
-      expect(wrapper.find('textarea[id="category-summary"]').exists()).toBe(true)
+      expect(wrapper.find('#category-item').exists()).toBe(true)
+      expect(wrapper.find('#category-summary').exists()).toBe(true)
 
       // ボタン要素
-      expect(wrapper.find('button').exists()).toBe(true)
+      expect(wrapper.find('button').text()).toBe('登録')
     })
 
     it('外部リンクが表示されること', () => {
@@ -78,8 +78,8 @@ describe('CategoriesNewView', () => {
 
       await flushPromises()
 
-      const itemInput = wrapper.find('input[id="category-item"]')
-      const summaryTextArea = wrapper.find('textarea[id="category-summary"]')
+      const itemInput = wrapper.find('#category-item')
+      const summaryTextArea = wrapper.find('#category-summary')
 
       await itemInput.setValue('めっき')
       await summaryTextArea.setValue('金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。')
@@ -111,8 +111,8 @@ describe('CategoriesNewView', () => {
 
       await flushPromises()
       
-      const itemInput = wrapper.find('input[id="category-item"]')
-      const summaryTextArea = wrapper.find('textarea[id="category-summary"]')
+      const itemInput = wrapper.find('#category-item')
+      const summaryTextArea = wrapper.find('#category-summary')
 
       await itemInput.setValue('')
       await summaryTextArea.setValue('金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。')

--- a/frontend/test/components/categories/CategoriesShowView.test.js
+++ b/frontend/test/components/categories/CategoriesShowView.test.js
@@ -85,7 +85,7 @@ describe('CategoriesShowView', () => {
         }
       })
 
-      const wrapper = mount(CategoriesShowView, {
+      wrapper = mount(CategoriesShowView, {
         global: {
           stubs: {
             RouterLink: RouterLinkStub
@@ -115,7 +115,7 @@ describe('CategoriesShowView', () => {
         }
       })
 
-      const wrapper = mount(CategoriesShowView, {
+      wrapper = mount(CategoriesShowView, {
         global: {
           stubs: {
             RouterLink: RouterLinkStub
@@ -153,7 +153,7 @@ describe('CategoriesShowView', () => {
         }
       })
 
-      const wrapper = mount(CategoriesShowView, {
+      wrapper = mount(CategoriesShowView, {
         global: {
           stubs: {
             RouterLink: RouterLinkStub


### PR DESCRIPTION
## タスク
- [x] CategoriesEditView.test.js
- [x] CategoriesIndexView.test.js
- [x] CategoriesNewView.test.js
- [x] CategoriesShowView.test.js

#### 追加タスク
- 全体
  - [x] input 要素の検索方法を「#」に変更
  - [x] import エリアの整列
  - [x] let wrapper と const wrapper の重複解消
- CategoriesIndexView.test.js 
  - [x] 「ラベルが表示されること」を削除
- CategoriesNewView.test.js
  - [x] ボタン要素の検証をテキスト検証に変更