### PR TITLE
Comments / edit コンポーネントの実装

### DIFF
--- a/frontend/src/components/comments/CommentsEditView.vue
+++ b/frontend/src/components/comments/CommentsEditView.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="container w-25">
+    <h3 class="text-center mt-5 mb-5">
+      コメント情報の編集
+    </h3>
+  </div>
+</template>

--- a/frontend/src/components/comments/CommentsEditView.vue
+++ b/frontend/src/components/comments/CommentsEditView.vue
@@ -1,7 +1,78 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import axios from 'axios'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const emit = defineEmits(['message'])
+const route = useRoute()
+const router = useRouter()
+const comment = ref('')
+
+const fetchCommentData = async (id) => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/comments/${id}`)
+    comment.value = response.data
+  } catch (error) {
+    if (error.response && error.response.status === 404) {
+      emit('message', { type: 'danger', text: 'コメント情報の取得に失敗しました。' })
+      router.replace({ name: 'NotFound' })
+    }
+  }
+}
+
+onMounted(() => {
+  fetchCommentData(route.params.id)
+})
+</script>
+
 <template>
   <div class="container w-25">
     <h3 class="text-center mt-5 mb-5">
       コメント情報の編集
     </h3>
+
+    <form>
+      <label class="form-label" for="commenter">
+        投稿者
+      </label>
+      <input
+        v-model="comment.commenter"
+        class="form-control mb-4"
+        type="text"
+        id="commenter"
+        disabled
+      />
+
+      <label class="form-label" for="department">
+        部署名
+      </label>
+      <input
+        v-model="comment.department"
+        class="form-control mb-4"
+        type="text"
+        id="department"
+        disabled
+      />
+
+      <label class="form-label" for="body">
+        コメント
+      </label>
+      <textarea v-model="comment.body" class="form-control mb-5" id="body">
+      </textarea>
+      
+      <button type="submit" class="form-control btn btn-primary mb-5">
+        更新
+      </button>
+    </form>
+
+    <div class="d-flex justify-content-evenly">
+      <RouterLink v-bind:to="`/comments/${comment.id}`">
+        コメント情報へ
+      </RouterLink>
+      <RouterLink to="/comments">
+        コメントリストへ
+      </RouterLink>
+    </div>
   </div>
 </template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -31,9 +31,9 @@ import DepartmentsEditView from '@/components/departments/DepartmentsEditView.vu
 import CommentsIndexView from '@/components/comments/CommentsIndexView.vue'
 import CommentsShowView from '@/components/comments/CommentsShowView.vue'
 import CommentsNewView from '@/components/comments/CommentsNewView.vue'
+import CommentsEditView from '@/components/comments/CommentsEditView.vue'
 
 import NotFound from '@/components/not_found/NotFound.vue'
-
 
 const history = import.meta.env.MODE === 'test' ? createMemoryHistory() : createWebHistory()
 
@@ -74,7 +74,8 @@ const routes = [
   { path: '/comments', component: CommentsIndexView, meta: { title: 'Comments Index' } },
   { path: '/comments/:id', component: CommentsShowView, meta: { title: 'Comments Show' } },
   { path: '/comments/new', component: CommentsNewView, meta: { title: 'Comments New' } },
-  
+  { path: '/comments/:id/edit', component: CommentsEditView, meta: { title: 'Comments Edit' } },
+
   { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound, meta: { title: 'NotFound (404)' } },
 ]
 

--- a/frontend/test/components/comments/CommentsEditView.test.js
+++ b/frontend/test/components/comments/CommentsEditView.test.js
@@ -1,0 +1,118 @@
+import CommentsEditView from '@/components/comments/CommentsEditView.vue'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises, RouterLinkStub } from '@vue/test-utils'
+import axios from 'axios'
+
+const replaceMock = vi.fn()
+const pushMock = vi.fn()
+
+vi.mock('axios')
+vi.mock('vue-router', () => {
+  return {
+    useRoute: () => {
+      return {
+        params: { id: 1 }
+      }
+    },
+    useRouter: () => {
+      return {
+        replace: replaceMock,
+        push: pushMock
+      }
+    }
+  }
+})
+
+describe('CommentsEditView', () => {
+  let wrapper
+
+  describe('初期レンダリングに成功した場合', () => {
+    beforeEach(async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          id: 1,
+          commenter: '工藤 琴音',
+          body: '製品に高級感を与える仕上がりで、見た目も美しいです。',
+          sample_id: 16,
+          department: '品質管理部'
+        }
+      })
+
+      wrapper = mount(CommentsEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
+    it('見出しが表示されること', () => {
+      expect(wrapper.find('h3').text()).toBe('コメント情報の編集')
+    })
+
+    it('入力フォームが表示されること', () => {
+      // フォーム要素
+      expect(wrapper.find('form').exists()).toBe(true)
+
+      // ラベル要素
+      expect(wrapper.find('label[for="commenter"]').text()).toBe('投稿者')
+      expect(wrapper.find('label[for="department"]').text()).toBe('部署名')
+      expect(wrapper.find('label[for="body"]').text()).toBe('コメント')
+
+      // 入力要素
+      expect(wrapper.find('#commenter').element.value).toBe('工藤 琴音')
+      expect(wrapper.find('#department').element.value).toBe('品質管理部')
+      
+      // テキストエリア要素
+      expect(wrapper.find('#body').element.value).toBe(
+        '製品に高級感を与える仕上がりで、見た目も美しいです。'
+      )
+
+      // ボタン要素
+      expect(wrapper.find('button').text()).toBe('更新')
+    })
+
+    it('外部リンクが表示されること', () => {
+      const routerLink = wrapper.findAllComponents(RouterLinkStub)
+
+      // to属性
+      expect(routerLink[0].props().to).toBe('/comments/1')
+      expect(routerLink[1].props().to).toBe('/comments')
+
+      // テキスト
+      expect(routerLink[0].text()).toBe('コメント情報へ')
+      expect(routerLink[1].text()).toBe('コメントリストへ')
+    })
+  })
+
+  describe('初期レンダリングに失敗した場合', () => {
+    beforeEach(async () => {
+      axios.get.mockRejectedValue({
+        response: {
+          status: 404
+        }
+      })
+
+      wrapper = mount(CommentsEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
+    it('404ページに遷移すること', () => {
+      expect(wrapper.emitted()).toHaveProperty('message')
+      expect(wrapper.emitted().message[0]).toEqual([
+        { type: 'danger', text: 'コメント情報の取得に失敗しました。' }
+      ])
+      expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
+    })
+  })
+})

--- a/frontend/test/components/comments/CommentsEditView.test.js
+++ b/frontend/test/components/comments/CommentsEditView.test.js
@@ -115,4 +115,86 @@ describe('CommentsEditView', () => {
       expect(replaceMock).toHaveBeenCalledWith({ name: 'NotFound' })
     })
   })
+
+  describe('更新に成功した場合', () => {
+    beforeEach(async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          id: 1,
+          commenter: '工藤 琴音',
+          body: '製品に高級感を与える仕上がりで、見た目も美しいです。',
+          sample_id: 16,
+          department: '品質管理部'
+        }
+      })
+
+      axios.patch.mockResolvedValue({
+        data: {
+          id: 1,
+          commenter: '工藤 琴音',
+          body: '製品に高級感を与える仕上がりで、品質も良好です。',
+          sample_id: 16,
+          department: '品質管理部'
+        }
+      })
+
+      wrapper = mount(CommentsEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
+    it('コメント情報ページに遷移すること', async () => {
+      await wrapper.find('#body').setValue('製品に高級感を与える仕上がりで、品質も良好です。')
+      await wrapper.find('form').trigger('submit.prevent')
+
+      expect(wrapper.emitted()).toHaveProperty('message')
+      expect(wrapper.emitted().message[0]).toEqual([
+        { type: 'success', text: 'コメント情報を更新しました。' }
+      ])
+      expect(pushMock).toHaveBeenCalledWith('/comments/1')
+    })
+  })
+
+  describe('更新に失敗した場合', () => {
+    beforeEach(async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          id: 1,
+          commenter: '工藤 琴音',
+          body: '製品に高級感を与える仕上がりで、見た目も美しいです。',
+          sample_id: 16,
+          department: '品質管理部'
+        }
+      })
+
+      axios.patch.mockRejectedValue({
+        response: {
+          status: 422
+        }
+      })
+
+      wrapper = mount(CommentsEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
+    it('入力不備のメッセージが表示されること', async () => {
+      await wrapper.find('#body').setValue('')
+      await wrapper.find('form').trigger('submit.prevent')
+
+      expect(wrapper.find('p').text()).toBe('入力に不備があります。')
+    })
+  })
 })

--- a/frontend/test/e2e/routing.test.js
+++ b/frontend/test/e2e/routing.test.js
@@ -40,6 +40,7 @@ const routes = [
   { path: '/comments', component: () => import('@/components/comments/CommentsIndexView.vue'), meta: { title: 'Comments Index' } },
   { path: '/comments/:id', component: () => import('@/components/comments/CommentsShowView.vue'), meta: { title: 'Comments Show' } },
   { path: '/comments/new', component: () => import('@/components/comments/CommentsNewView.vue'), meta: { title: 'Comments New' } },
+  { path: '/comments/:id/edit', component: () => import('@/components/comments/CommentsEditView.vue'), meta: { title: 'Comments Edit' } },
 
   { path: '/:pathMatch(.*)*', name: 'NotFound', component: () => import('@/components/not_found/NotFound.vue'), meta: { title: 'NotFound (404)' } },
 ]
@@ -859,8 +860,28 @@ describe('Comments routing', () => {
     expect(wrapper.find('h3').text()).toBe('コメント情報の新規登録') 
   })
 
-  // edit・update
+  it('「コメント情報の編集」ページに遷移すること', async () => {
+    const router = createAppRouter()
 
+    router.push('/comments/1/edit')
+
+    await router.isReady()
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router],
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(router.currentRoute.value.meta.title).toBe('Comments Edit')
+    expect(document.title).toBe('Comments Edit')
+    expect(wrapper.find('h3').text()).toBe('コメント情報の編集') 
+  })
 })
 
 describe('NotFound routing', () => {


### PR DESCRIPTION
## ファイル名
コンポーネント：CommentsEditView.vue
テスト：CommentsEditView.test.js
ルート：comments/:id/edit

## タスク
- [x] ルーティング
  - [x] コンポーネント（見出しのみ）
  - [x] マッピング
  - [x] テスト
- [x] コンポーネント
  - edit
    - [x] スクリプト
    - [x] テンプレート
    - [x] テスト
  - update
    - [x] スクリプト
    - [x] テンプレート
    - [x] テスト