### PR TITLE
checkLoginStatus 関数のモジュール化

### DIFF
--- a/frontend/src/components/categories/CategoriesIndexView.vue
+++ b/frontend/src/components/categories/CategoriesIndexView.vue
@@ -2,27 +2,12 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
+import { checkLoginStatus } from '../utils.js'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 const emit = defineEmits(['message'])
 const router = useRouter()
 const categories = ref([])
-
-const checkLoginStatus = async () => {
-  const token = localStorage.getItem('token')
-  try {
-    await axios.get(`${API_BASE_URL}/logged_in`, {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
-  } catch (error) {
-    if (error.response && error.response.status === 401) {
-      emit('message', { type: 'danger', text: 'ログインが必要です。' })
-      router.push('/')
-    }
-  }
-}
 
 function replaceStringWithEllipsis() {
   for (const category of categories.value) {
@@ -45,9 +30,12 @@ const fetchCategoryList = async () => {
   }
 }
 
-onMounted(() => {
-  checkLoginStatus()
-  fetchCategoryList()
+onMounted(async () => {
+  await checkLoginStatus(() => {
+    emit('message', { type: 'danger', text: 'ログインが必要です。' })
+    router.push('/')
+  })
+  await fetchCategoryList()
 })
 </script>
 

--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -1,0 +1,18 @@
+import axios from 'axios'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+export const checkLoginStatus = async (onUnauthorized) => {
+  const token = localStorage.getItem('token')
+  try {
+    await axios.get(`${API_BASE_URL}/logged_in`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+  } catch (error) {
+    if (error.response && error.response.status === 401) {
+      if (onUnauthorized) onUnauthorized()
+    }
+  }
+}

--- a/frontend/test/units/utils.test.js
+++ b/frontend/test/units/utils.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import { checkLoginStatus } from '@/components/utils.js'
+
+vi.mock('axios')
+
+describe('checkLoginStatus', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('token', 'dummy-token')
+  })
+
+  describe('レスポンスのステータスが 200 の場合', () => {
+    it('onUnauthorized が呼ばれないこと', async () => {
+      axios.get.mockResolvedValue({
+        response: {
+          status: 200
+        }
+      })
+
+      const onUnauthorized = vi.fn()
+      await checkLoginStatus(onUnauthorized)
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/logged_in'),
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer dummy-token' }
+        })
+      )
+      expect(onUnauthorized).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('レスポンスのステータスが 401 の場合', () => {
+    it('onUnauthorized が呼ばれること', async () => {
+      axios.get.mockRejectedValue({
+        response: {
+          status: 401
+        }
+      })
+
+      const onUnauthorized = vi.fn()
+      await checkLoginStatus(onUnauthorized)
+
+      expect(onUnauthorized).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## タスク

### Frontend
- CategoriesIndexView.vue
  - [x] checkLoginStatus 関数を utils.js に移動（utils.js は src/components に新規作成）
- utils.js
  - [x] checkLoginStatus の単体テスト

### Backend
変更なし