### PR TITLE
Edit ページのレイアウト変更と機能追加：categories

### DIFF
--- a/frontend/src/components/categories/CategoriesEditView.vue
+++ b/frontend/src/components/categories/CategoriesEditView.vue
@@ -37,6 +37,10 @@ const categoryUpdate = async () => {
   }
 }
 
+const cancel = () => {
+  router.push(`/categories/${category.value.id}`)
+}
+
 onMounted(async () => {
   const loggedIn = await checkLoginStatus(() => {
     emit('message', { type: 'danger', text: 'ログインが必要です。' })
@@ -80,7 +84,7 @@ onMounted(async () => {
         <button type="submit" class="btn btn-primary me-md-2">
           更新
         </button>
-        <button type="button" class="btn btn-outline-secondary">
+        <button v-on:click="cancel" type="button" class="btn btn-outline-secondary">
           キャンセル
         </button>
       </div>

--- a/frontend/test/components/categories/CategoriesEditView.test.js
+++ b/frontend/test/components/categories/CategoriesEditView.test.js
@@ -260,4 +260,38 @@ describe('CategoriesEditView', () => {
       expect(wrapper.text()).toContain('入力に不備があります。')
     })
   })
+
+  describe('キャンセルボタンを押した場合', () => {
+    beforeEach(async () => {
+      axios.get
+        .mockResolvedValueOnce({
+          status: 200
+        })
+        .mockResolvedValueOnce({
+          data: {
+            id: 1,
+            item: 'めっき',
+            summary: '金属または非金属の材料の表面に金属の薄膜を被覆する処理のこと。'
+          }
+        })
+
+      wrapper = mount(CategoriesEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
+    it('/categories/1が呼び出されること', async () => {
+      const cancelButton = wrapper.find('button[type="button"]')
+
+      await cancelButton.trigger('click')
+
+      expect(pushMock).toHaveBeenCalledWith('/categories/1')
+    })
+  })
 })

--- a/frontend/tests/resources-manage-flow/categories/categories-edit.spec.js
+++ b/frontend/tests/resources-manage-flow/categories/categories-edit.spec.js
@@ -24,4 +24,15 @@ test.describe('categories edit flow', () => {
       await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
     })
   })
+
+  test.describe('キャンセルボタンを押した場合', () => {
+    test('表面処理ページに移動すること', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
+
+      await page.getByRole('button', { name: 'キャンセル' }).click()
+
+      await expect(page).toHaveURL('/categories/1/edit')
+      await expect(page.getByRole('heading', { name: 'カテゴリー情報' })).toBeVisible()
+    })
+  })
 })


### PR DESCRIPTION
## タスク
- レイアウト変更
  - [x] キャンセルボタンの追加
  - [x] Show ページと Index ページのリンクを削除
- [x] キャンセルボタンを押した時の処理
