### PR TITLE
Edit ページのレイアウト変更と機能追加：users

### DIFF
--- a/frontend/src/components/users/UsersEditView.vue
+++ b/frontend/src/components/users/UsersEditView.vue
@@ -52,6 +52,10 @@ const fetchUserInformation = async () => {
   }
 }
 
+const cancel = () => {
+  router.push(`/users/${user.value.id}`)
+}
+
 onMounted(async () => {
   const loggedIn = await checkLoginStatus(() => {
     emit('message', { type: 'danger', text: 'ログインが必要です。' })
@@ -116,6 +120,7 @@ onMounted(async () => {
           更新
         </button>
         <button
+          v-on:click="cancel"
           type="button"
           class="btn btn-outline-secondary"
         >

--- a/frontend/test/components/users/UsersEditView.test.js
+++ b/frontend/test/components/users/UsersEditView.test.js
@@ -244,4 +244,38 @@ describe('UsersEditView', () => {
       expect(wrapper.text()).toContain('入力に不備があります。')
     })
   })
+
+  describe('キャンセルボタンを押した場合', () => {
+    beforeEach(async () => {
+      axios.get
+        .mockResolvedValueOnce({
+          status: 200
+        })
+        .mockResolvedValueOnce({
+          data: {
+            id: 1,
+            name: '渡辺 陸斗',
+            department: '開発部'
+          }
+        })
+
+      wrapper = mount(UsersEditView, {
+        global: {
+          stubs: {
+            RouterLink: RouterLinkStub
+          }
+        }
+      })
+
+      await flushPromises()
+    })
+
+    it('ユーザー情報ページに移動すること', async () => {
+      const cancelButton = wrapper.find('button[type="button"]')
+
+      await cancelButton.trigger('click')
+
+      expect(pushMock).toHaveBeenCalledWith('/users/1')
+    })
+  })
 })

--- a/frontend/tests/resources-manage-flow/users/users-edit.spec.js
+++ b/frontend/tests/resources-manage-flow/users/users-edit.spec.js
@@ -24,4 +24,15 @@ test.describe('users edit flow', () => {
       await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
     })
   })
+
+  test.describe('キャンセルボタンを押した場合', () => {
+    test('ユーザー情報ページに移動すること', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
+
+      await page.getByRole('button', { name: 'キャンセル' }).click()
+
+      await expect(page).toHaveURL('/users/1')
+      await expect(page.getByRole('heading', { name: 'ユーザー情報' })).toBeVisible()
+    })
+  })
 })


### PR DESCRIPTION
## タスク
- レイアウト変更
  - [x] キャンセルボタンの追加
  - [x] Show ページと Index ページのリンクを削除
- [x] キャンセルボタンを押した時の処理