### PR TITLE
rubocop-performance のアップデート

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -29,7 +29,7 @@ group :development do
   gem "better_errors"
   gem "binding_of_caller"
   gem "rubocop", '1.82.1', require: false
-  gem 'rubocop-performance', '1.26.0', require: false
+  gem 'rubocop-performance', '1.26.1', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', '3.9.0', require: false
   gem 'bullet'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -293,10 +293,10 @@ GEM
     rubocop-ast (1.48.0)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
-    rubocop-performance (1.26.0)
+    rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
-      rubocop-ast (>= 1.44.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
     rubocop-rails (2.32.0)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
@@ -371,7 +371,7 @@ DEPENDENCIES
   rails (= 7.2.2)
   rspec-rails
   rubocop (= 1.82.1)
-  rubocop-performance (= 1.26.0)
+  rubocop-performance (= 1.26.1)
   rubocop-rails
   rubocop-rspec (= 3.9.0)
   simplecov


### PR DESCRIPTION
## タスク
  - [x] 1.26.0 
  - [x] 1.26.1