### PR TITLE
Sample.film_thickness_search の作成

### DIFF
--- a/backend/app/controllers/searches_controller.rb
+++ b/backend/app/controllers/searches_controller.rb
@@ -23,10 +23,23 @@ class SearchesController < ApplicationController
     render json: samples, status: :ok
   end
 
+  def film_thickness_search
+    samples = Sample.film_thickness_search(min_film_thickness, max_film_thickness)
+    render json: samples, status: :ok
+  end
+
   private
 
     def set_keyword
       @keyword = params[:keyword]
+    end
+
+    def min_film_thickness
+      params[:min_film_thickness].to_i
+    end
+
+    def max_film_thickness
+      params[:max_film_thickness].to_i
     end
 
     def render_samples(samples)

--- a/backend/app/models/sample.rb
+++ b/backend/app/models/sample.rb
@@ -30,6 +30,11 @@ class Sample < ApplicationRecord
 
   scope :name_search, -> (keyword) { where('name LIKE ?', "%#{keyword}%") }
 
+  scope :film_thickness_search, -> (min, max) do
+    samples = order(:id)
+    samples.select { |sample| (min..max).cover?(sample.film_thickness.slice(/\d+/).to_i) }
+  end
+
   def image_url
     image.attached? ? url_for(image) : nil  
   end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,10 +5,11 @@ Rails.application.routes.draw do
   delete '/logout',    to: 'sessions#destroy'
   get    '/logged_in', to: 'sessions#logged_in'
 
-  get '/name_search',     to: 'searches#name_search'
-  get '/category_search', to: 'searches#category_search'
-  get '/maker_search',    to: 'searches#maker_search'
-  get '/list_search', to: 'searches#list_search'
+  get '/name_search',           to: 'searches#name_search'
+  get '/category_search',       to: 'searches#category_search'
+  get '/maker_search',          to: 'searches#maker_search'
+  get '/list_search',           to: 'searches#list_search'
+  get '/film_thickness_search', to: 'searches#film_thickness_search'
 
   get '/comments/:id', to: 'comments#comment_information', as: 'comment_information'
   get '/comments', to: 'comments#comment_list', as: 'comment_list'

--- a/backend/spec/models/sample_spec.rb
+++ b/backend/spec/models/sample_spec.rb
@@ -123,5 +123,36 @@ RSpec.describe Sample, type: :model do
         end
       end
     end
+
+    describe '.film_thickness_search' do
+      describe '膜厚 5μm に該当するサンプルの取得可否' do
+        let!(:sample) { FactoryBot.create(:sample) }
+
+        context '最小膜厚に 3, 最大膜厚に 7 を指定した場合' do
+          it 'サンプルが取得できる' do
+            samples = Sample.film_thickness_search(3, 7)
+            expect(samples[0].film_thickness).to eq('5μm')
+          end
+        end
+
+        context '最小膜厚に 1, 最大膜厚に 4 を指定した場合' do
+          it 'サンプルは取得できずに空の配列が返る' do
+            samples = Sample.film_thickness_search(1, 4)
+            expect(samples).to eq([])
+          end
+        end
+      end
+
+      describe '2 桁以上の膜厚に該当するサンプルの取得可否' do
+        let!(:sample) { FactoryBot.create(:sample, film_thickness: '10μm') }
+
+        context '最小膜厚に 6, 最大膜厚に 15 を指定した場合' do
+          it '膜厚 10μm に該当するサンプルが取得できる' do
+            samples = Sample.film_thickness_search(6, 15)
+            expect(samples[0].film_thickness).to eq('10μm')
+          end
+        end
+      end
+    end
   end
 end

--- a/backend/spec/requests/searches_spec.rb
+++ b/backend/spec/requests/searches_spec.rb
@@ -60,4 +60,23 @@ RSpec.describe "Searches", type: :request do
       ).to match_array(%w(id name summary image_url))
     end
   end
+
+  describe '#film_thickness_search' do
+    it 'レスポンスのステータスが ok であること' do
+      get film_thickness_search_path, params: {
+        min_film_thickness: '3',
+        max_film_thickness: '7'
+      }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '指定した膜厚範囲に該当するサンプルが取得できる' do
+      get film_thickness_search_path, params: {
+        min_film_thickness: '3',
+        max_film_thickness: '7'
+      }
+      json = response.parsed_body
+      expect(json[0][:film_thickness]).to eq('5μm')
+    end
+  end
 end


### PR DESCRIPTION
## タスク
- Sample モデル
  - [x] film_thickness_search スコープを追加
  - [x] 戻り値の検証は console で実施
- [x] searches コントローラ
  - [x] film_thickness_search アクションを追加
  - [x] /film_thickness_search ルーティングを追加
  - [x] 戻り値の検証は curl で実施
- [x] テスト
  - [x] model spec
  - [x] request spec