### PR TITLE
各ページの疎通

### DIFF
--- a/frontend/src/components/search_results/FilmThickness.vue
+++ b/frontend/src/components/search_results/FilmThickness.vue
@@ -1,25 +1,33 @@
 <script setup>
-import { ref, reactive, onMounted, computed } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { checkLoginStatus } from '@/components/utils.js'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import axios from 'axios'
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 const emit = defineEmits(['message'])
 const router = useRouter()
-const minFilmThickness = ref(3)
-const maxFilmThickness = ref(7)
+const route = useRoute()
+const samples = ref([])
+const minFilmThickness = route.query.min_film_thickness
+const maxFilmThickness = route.query.max_film_thickness
 
-const samples = reactive([
-  {
-    id: 1,
-    name: '無電解ニッケルめっき',
-    film_thickness: '5μm',
-    feature: '耐食性・耐摩耗性・耐薬品性・耐熱性',
-    color: 'イエローブラウンシルバー',
-  },
-])
+const fetchSamples = async () => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/film_thickness_search`, {
+      params: { min_film_thickness: minFilmThickness, max_film_thickness: maxFilmThickness },
+    })
+    samples.value = response.data
+  } catch (error) {
+    if (error.response && error.response.status === 404) {
+      emit('message', { type: 'danger', text: 'サンプルの取得に失敗しました。' })
+      router.replace({ name: 'NotFound' })
+    }
+  }
+}
 
 const searchResultMessage = computed(() => {
-  return `${ minFilmThickness.value } μm から ${ maxFilmThickness.value } μm の範囲で ${ samples.length } 件該当`
+  return `${ minFilmThickness } μm から ${ maxFilmThickness } μm の範囲で ${ samples.value.length } 件該当`
 })
 
 onMounted(async () => {
@@ -27,6 +35,7 @@ onMounted(async () => {
     emit('message', { type: 'danger', text: 'ログインが必要です。' })
     router.push('/')
   })
+  await fetchSamples()
 })
 </script>
 

--- a/frontend/src/components/static_pages/HomeView.vue
+++ b/frontend/src/components/static_pages/HomeView.vue
@@ -84,7 +84,7 @@ onMounted(async () => {
             :icon="filmThickness"
             card-title="変寸量で検索"
             card-text="変寸量を指定して目的の処理を検索します。"
-            to-attribute="#"
+            to-attribute="/static_pages/film_thickness"
             link-text="検索ページへ"
           />
         </div>

--- a/frontend/test/components/search_results/FilmThickness.test.js
+++ b/frontend/test/components/search_results/FilmThickness.test.js
@@ -1,19 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { flushPromises, RouterLinkStub, mount} from '@vue/test-utils'
-import { nextTick } from 'vue'
+import axios from 'axios'
 import FilmThickness from '@/components/search_results/FilmThickness.vue'
 
-const { pushMock } = vi.hoisted(() => {
+const { replaceMock, pushMock, mockRoute } = vi.hoisted(() => {
   return {
+    replaceMock: vi.fn(),
     pushMock: vi.fn(),
+    mockRoute: { query: { min_film_thickness: 3, max_film_thickness: 7 } },
   }
 })
 
 vi.mock('axios')
 vi.mock('vue-router', () => {
   return {
+    useRoute: () => mockRoute,
     useRouter: () => {
       return {
+        replace: replaceMock,
         push: pushMock,
       }
     }
@@ -21,6 +25,16 @@ vi.mock('vue-router', () => {
 })
 
 describe('FilmThickness Component', () => {
+  const mockResponse = [
+    {
+      id: 1,
+      name: '無電解ニッケルめっき',
+      color: 'イエローブラウンシルバー',
+      film_thickness: '5μm',
+      feature: '耐食性・耐摩耗性・耐薬品性・耐熱性',
+    }
+  ]
+
   const mountComponent = () => mount(FilmThickness, {
     global: {
       stubs: {
@@ -35,6 +49,10 @@ describe('FilmThickness Component', () => {
 
   describe('初期レンダリングの検証', () => {
     it('見出しが表示される', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce({ status: 200 })         // checkLoginStatus()
+        .mockResolvedValueOnce({ data: mockResponse })  // fetchSamples()
+
       const wrapper = mountComponent()
       await flushPromises()
 
@@ -42,6 +60,10 @@ describe('FilmThickness Component', () => {
     })
 
     it('検索条件と該当件数が表示される', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce({ status: 200 })         // checkLoginStatus()
+        .mockResolvedValueOnce({ data: mockResponse })  // fetchSamples()
+
       const wrapper = mountComponent()
       await flushPromises()
 
@@ -49,27 +71,34 @@ describe('FilmThickness Component', () => {
     })
 
     it('該当する表面処理情報がリンク付きで表示される', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce({ status: 200 })         // checkLoginStatus()
+        .mockResolvedValueOnce({ data: mockResponse })  // fetchSamples()
+
       const wrapper = mountComponent()
       await flushPromises()
 
       const routerLink = wrapper.findComponent(RouterLinkStub)
-      const sample = wrapper.vm.samples[0]
 
-      expect(routerLink.props().to).toBe(`/samples/${sample.id}`)
-      expect(routerLink.text()).toContain(sample.name)
-      expect(routerLink.text()).toContain(sample.feature)
-      expect(routerLink.text()).toContain(sample.film_thickness)
-      expect(routerLink.text()).toContain(sample.color)
+      expect(routerLink.props().to).toBe(`/samples/${mockResponse[0].id}`)
+      expect(routerLink.text()).toContain(mockResponse[0].name)
+      expect(routerLink.text()).toContain(mockResponse[0].feature)
+      expect(routerLink.text()).toContain(mockResponse[0].film_thickness)
+      expect(routerLink.text()).toContain(mockResponse[0].color)
     })
 
     it('ナビゲージョンリンクが表示される', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce({ status: 200 })         // checkLoginStatus()
+        .mockResolvedValueOnce({ data: mockResponse })  // fetchSamples()
+
       const wrapper = mountComponent()
       await flushPromises()
 
       const nav = wrapper.find('.nav')
       const routerLinks = nav.findAllComponents(RouterLinkStub)
 
-      // 再検索リンク
+      // 再検索
       expect(routerLinks[0].props().to).toBe('/static_pages/film_thickness')
       expect(routerLinks[0].text()).toBe('再検索')
 
@@ -81,33 +110,29 @@ describe('FilmThickness Component', () => {
 
   describe('searchResultMessage の検証', () => {
     it('minFilmThickness と minFilmThickness を変更すると再計算される', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce({ status: 200 })         // checkLoginStatus()
+        .mockResolvedValueOnce({ data: mockResponse })  // fetchSamples()
+
+      mockRoute.query.min_film_thickness = 4
+      mockRoute.query.max_film_thickness = 6
+
       const wrapper = mountComponent()
       await flushPromises()
 
-      wrapper.vm.minFilmThickness = 4
-      wrapper.vm.maxFilmThickness = 6
-      await nextTick()
-
-      expect(wrapper.vm.searchResultMessage).toBe('4 μm から 6 μm の範囲で 1 件該当')
+      expect(wrapper.text()).toContain('4 μm から 6 μm の範囲で 1 件該当')
     })
 
-    it('samples が 0 件のとき「0 件該当」になる', async () => {
+    it('最小膜厚が 8 で最大膜厚が 12 の場合、「該当する表面処理が無い」メッセージが表示される', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce({ status: 200 })  // checkLoginStatus()
+        .mockResolvedValueOnce({ data: [] })     // fetchSamples()
+
+      mockRoute.query.min_film_thickness = 8
+      mockRoute.query.max_film_thickness = 12
+
       const wrapper = mountComponent()
       await flushPromises()
-
-      wrapper.vm.samples.splice(0, wrapper.vm.samples.length)
-      await nextTick()
-
-      expect(wrapper.vm.searchResultMessage).toBe('3 μm から 7 μm の範囲で 0 件該当')
-      expect(wrapper.text()).toContain('該当する表面処理はありませんでした。')
-    })
-
-    it('samples が 0 件のとき「該当する表面処理が無い」メッセージが表示される', async () => {
-      const wrapper = mountComponent()
-      await flushPromises()
-
-      wrapper.vm.samples.splice(0, wrapper.vm.samples.length)
-      await nextTick()
 
       expect(wrapper.text()).toContain('該当する表面処理はありませんでした。')
     })

--- a/frontend/test/components/static_pages/HomeView.test.js
+++ b/frontend/test/components/static_pages/HomeView.test.js
@@ -143,7 +143,7 @@ describe('HomeView', () => {
       expect(div.find('img').attributes('alt')).toBe('film-thickness icon')
       expect(div.find('div h5').text()).toBe('変寸量で検索')
       expect(div.find('div div.card-text').text()).toBe('変寸量を指定して目的の処理を検索します。')
-      expect(routerLink.props().to).toBe('#')
+      expect(routerLink.props().to).toBe('/static_pages/film_thickness')
       expect(routerLink.text()).toBe('検索ページへ')
     })
 


### PR DESCRIPTION
## タスク
- [x] メインメニューページと変寸量で検索ページの疎通
  - [x] HomeView.test.js の修正
- [x] 変寸量で検索ページと表面処理の検索結果ページの疎通
  - [x] search_results/FilmThickness.test.js の修正